### PR TITLE
fix(item): restore interceptPlayClick to suppress version dialog for movies

### DIFF
--- a/app/src/main/java/com/makd/afinity/ui/item/ItemDetailScreen.kt
+++ b/app/src/main/java/com/makd/afinity/ui/item/ItemDetailScreen.kt
@@ -198,7 +198,7 @@ fun ItemDetailScreen(
                     downloadInfo = uiState.downloadInfo,
                     tmdbReviews = uiState.tmdbReviews,
                     mdbRatings = uiState.mdbRatings,
-                    onPlayClick = { item, selection -> onPlayClick(item, selection) },
+                    onPlayClick = { item, selection -> interceptPlayClick(item, selection) },
                     onBoxSetItemClick = { item ->
                         if (item is AfinityEpisode) {
                             viewModel.selectEpisode(item)


### PR DESCRIPTION
Restores the `interceptPlayClick` call that was accidentally dropped during the merge conflict resolution of #75.

**What this fixes:**
- `onPlayClick` at the `ItemDetailScreen` composable call site was reverted to the original `onPlayClick(item, selection)` during merge
- This means the `VersionPickerDialog` was being shown for **all** items including movies, when it should be suppressed for movies (which already have version pills on the detail screen)

**Change:**
```diff
- onPlayClick = { item, selection -> onPlayClick(item, selection) },
+ onPlayClick = { item, selection -> interceptPlayClick(item, selection) },
```

Single line, no other changes.