### PR TITLE
perf: implement batched UI updates and add watchlist support

### DIFF
--- a/app/src/main/java/com/makd/afinity/data/database/AfinityDatabase.kt
+++ b/app/src/main/java/com/makd/afinity/data/database/AfinityDatabase.kt
@@ -101,7 +101,7 @@ import com.makd.afinity.data.models.user.User
             JellyfinStatsCacheEntity::class,
             AbsDownloadEntity::class,
         ],
-    version = 43,
+    version = 44,
     exportSchema = false,
 )
 @TypeConverters(AfinityTypeConverters::class)

--- a/app/src/main/java/com/makd/afinity/data/database/DatabaseMigrations.kt
+++ b/app/src/main/java/com/makd/afinity/data/database/DatabaseMigrations.kt
@@ -1055,6 +1055,13 @@ object DatabaseMigrations {
             }
         }
 
+    val MIGRATION_43_44 =
+        object : Migration(43, 44) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE userdata ADD COLUMN likes INTEGER NOT NULL DEFAULT 0")
+            }
+        }
+
     val ALL_MIGRATIONS =
         arrayOf(
             MIGRATION_1_2,
@@ -1099,5 +1106,6 @@ object DatabaseMigrations {
             MIGRATION_40_41,
             MIGRATION_41_42,
             MIGRATION_42_43,
+            MIGRATION_43_44,
         )
 }

--- a/app/src/main/java/com/makd/afinity/data/database/dao/ServerDatabaseDao.kt
+++ b/app/src/main/java/com/makd/afinity/data/database/dao/ServerDatabaseDao.kt
@@ -90,6 +90,7 @@ abstract class ServerDatabaseDao {
                     played = false,
                     favorite = false,
                     playbackPositionTicks = 0L,
+                    likes = false,
                 )
                 .also { insertUserData(it) }
     }

--- a/app/src/main/java/com/makd/afinity/data/database/dao/UserDataDao.kt
+++ b/app/src/main/java/com/makd/afinity/data/database/dao/UserDataDao.kt
@@ -7,8 +7,8 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
 import com.makd.afinity.data.models.user.AfinityUserDataDto
-import java.util.UUID
 import kotlinx.coroutines.flow.Flow
+import java.util.UUID
 
 @Dao
 interface UserDataDao {
@@ -79,6 +79,31 @@ interface UserDataDao {
 
     @Query("SELECT COUNT(*) FROM userdata WHERE userId = :userId AND serverId = :serverId")
     suspend fun getUserDataCount(userId: UUID, serverId: String): Int
+
+    @Query(
+        """
+        UPDATE userdata 
+        SET played = :isPlayed, 
+            playbackPositionTicks = :positionTicks, 
+            favorite = :isFavorite,
+            likes = :isLiked
+        WHERE itemId = :itemId 
+          AND userId = :userId 
+          AND serverId = :serverId
+    """
+    )
+    suspend fun patchUserDataLocally(
+        itemId: UUID,
+        userId: UUID,
+        serverId: String,
+        isPlayed: Boolean,
+        positionTicks: Long,
+        isFavorite: Boolean,
+        isLiked: Boolean,
+    )
+
+    @Query("SELECT * FROM userdata WHERE userId = :userId AND serverId = :serverId AND likes = 1")
+    fun getWatchlistItemsFlow(userId: UUID, serverId: String): Flow<List<AfinityUserDataDto>>
 
     @Query("DELETE FROM userdata") suspend fun deleteAllUserData()
 }

--- a/app/src/main/java/com/makd/afinity/data/manager/MediaChangeManager.kt
+++ b/app/src/main/java/com/makd/afinity/data/manager/MediaChangeManager.kt
@@ -4,14 +4,17 @@ import com.makd.afinity.data.models.media.AfinityEpisode
 import com.makd.afinity.data.models.media.AfinityItem
 import com.makd.afinity.data.models.media.AfinitySeason
 import com.makd.afinity.data.repository.AppDataRepository
+import com.makd.afinity.data.repository.DatabaseRepository
 import com.makd.afinity.data.repository.FieldSets
 import com.makd.afinity.data.repository.media.MediaRepository
 import com.makd.afinity.data.repository.watchlist.WatchlistRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.launch
 import org.jellyfin.sdk.model.api.UserItemDataDto
 import timber.log.Timber
@@ -19,12 +22,15 @@ import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
 
+@OptIn(FlowPreview::class)
 @Singleton
 class MediaChangeManager
 @Inject
 constructor(
     private val mediaRepository: MediaRepository,
     private val appDataRepository: AppDataRepository,
+    private val databaseRepository: DatabaseRepository,
+    private val sessionManager: SessionManager,
     private val watchlistRepository: WatchlistRepository,
 ) {
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
@@ -35,6 +41,17 @@ constructor(
     private val _libraryContentChanges =
         MutableSharedFlow<LibraryContentChangeEvent>(extraBufferCapacity = 16)
     val libraryContentChanges = _libraryContentChanges.asSharedFlow()
+
+    private val liveSectionRefreshTrigger = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+
+    init {
+        scope.launch {
+            liveSectionRefreshTrigger.debounce(1000L).collect {
+                Timber.d("WebSocket transfer finished. Syncing Next Up & Continue Watching...")
+                appDataRepository.refreshLiveSections()
+            }
+        }
+    }
 
     fun notifyLibraryContentChanged(reason: String) {
         scope.launch { _libraryContentChanges.emit(LibraryContentChangeEvent(reason)) }
@@ -57,58 +74,40 @@ constructor(
     }
 
     suspend fun applyUserDataChange(userData: UserItemDataDto) {
-        val updatedItem =
-            refreshAndPublish(
-                itemId = userData.itemId,
-                source = MediaChangeSource.WEBSOCKET,
-                userData = userData,
-            )
-
-        if (updatedItem != null) {
-            appDataRepository.updateFavoriteStatus(updatedItem, userData.isFavorite)
-            userData.likes?.let { isLiked ->
-                appDataRepository.updateWatchlistStatus(updatedItem, isLiked)
-                watchlistRepository.refreshWatchlistCount()
-            }
-        }
-
-        if (userData.played || userData.playbackPositionTicks > 0L) {
-            appDataRepository.refreshLiveSections()
-        }
+        applyUserDataChangesBatch(listOf(userData))
     }
 
     suspend fun applyUserDataChangesBatch(userDataList: List<UserItemDataDto>) {
-        val itemIds = userDataList.mapNotNull { it.itemId }
-        if (itemIds.isEmpty()) return
+        if (userDataList.isEmpty()) return
 
-        try {
-            val updatedItems = mediaRepository.getItemsByIds(itemIds)
+        val currentSession = sessionManager.currentSession.value ?: return
+        val userId = currentSession.userId
+        val serverId = currentSession.serverId
+        var requiresLiveSectionRefresh = false
 
-            var requiresLiveSectionRefresh = false
-            updatedItems.forEach { updatedItem ->
-                val correspondingUserData = userDataList.find { it.itemId == updatedItem.id }
-                appDataRepository.updateItemInCaches(updatedItem)
-                if (
-                    correspondingUserData?.played == true ||
-                        (correspondingUserData?.playbackPositionTicks ?: 0L) > 0L
-                ) {
-                    requiresLiveSectionRefresh = true
-                }
-                _mediaChanges.emit(
-                    MediaChangeEvent(
-                        itemId = updatedItem.id,
-                        updatedItem = updatedItem,
-                        source = MediaChangeSource.WEBSOCKET,
-                        userData = correspondingUserData,
-                    )
+        userDataList.forEach { userData ->
+            val itemId = userData.itemId ?: return@forEach
+            try {
+                databaseRepository.patchUserDataLocally(itemId, userId, serverId, userData)
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to patch local DB for $itemId")
+            }
+
+            _mediaChanges.emit(
+                MediaChangeEvent(
+                    itemId = itemId,
+                    source = MediaChangeSource.WEBSOCKET,
+                    userData = userData,
                 )
+            )
+
+            if (userData.played || (userData.playbackPositionTicks ?: 0L) > 0L) {
+                requiresLiveSectionRefresh = true
             }
-            if (requiresLiveSectionRefresh) {
-                Timber.d("Batch processed. Refreshing live sections once.")
-                appDataRepository.refreshLiveSections()
-            }
-        } catch (e: Exception) {
-            Timber.e(e, "Failed to process batch user data changes")
+        }
+
+        if (requiresLiveSectionRefresh) {
+            liveSectionRefreshTrigger.tryEmit(Unit)
         }
     }
 
@@ -221,7 +220,7 @@ constructor(
 
     private suspend fun refreshDerivedState(updatedItem: AfinityItem) {
         if (updatedItem is AfinityEpisode) {
-            appDataRepository.refreshLiveSections()
+            liveSectionRefreshTrigger.tryEmit(Unit)
         }
     }
 

--- a/app/src/main/java/com/makd/afinity/data/models/user/AfinityUserDataDto.kt
+++ b/app/src/main/java/com/makd/afinity/data/models/user/AfinityUserDataDto.kt
@@ -10,6 +10,7 @@ data class AfinityUserDataDto(
     val serverId: String,
     val played: Boolean,
     val favorite: Boolean,
+    val likes: Boolean,
     val playbackPositionTicks: Long,
     val toBeSynced: Boolean = false,
     val audioStreamIndex: Int? = null,

--- a/app/src/main/java/com/makd/afinity/data/repository/DatabaseRepository.kt
+++ b/app/src/main/java/com/makd/afinity/data/repository/DatabaseRepository.kt
@@ -21,6 +21,7 @@ import com.makd.afinity.data.models.server.ServerWithAddressesAndUsers
 import com.makd.afinity.data.models.user.AfinityUserDataDto
 import com.makd.afinity.data.models.user.User
 import kotlinx.coroutines.flow.Flow
+import org.jellyfin.sdk.model.api.UserItemDataDto
 import java.util.UUID
 
 interface DatabaseRepository {
@@ -159,6 +160,13 @@ interface DatabaseRepository {
 
     suspend fun updateUserData(userData: AfinityUserDataDto)
 
+    suspend fun patchUserDataLocally(
+        itemId: UUID,
+        userId: UUID,
+        serverId: String,
+        userData: UserItemDataDto,
+    )
+
     suspend fun deleteUserData(userId: UUID, itemId: UUID)
 
     suspend fun getUserData(userId: UUID, itemId: UUID): AfinityUserDataDto?
@@ -235,7 +243,11 @@ interface DatabaseRepository {
 
     suspend fun getSources(itemId: UUID): List<AfinitySourceDto>
 
-    suspend fun getItemMetadata(itemId: UUID, serverId: String, userId: String): ItemMetadataCacheEntity?
+    suspend fun getItemMetadata(
+        itemId: UUID,
+        serverId: String,
+        userId: String,
+    ): ItemMetadataCacheEntity?
 
     suspend fun insertItemMetadata(metadata: ItemMetadataCacheEntity)
 }

--- a/app/src/main/java/com/makd/afinity/data/repository/impl/DatabaseRepositoryImpl.kt
+++ b/app/src/main/java/com/makd/afinity/data/repository/impl/DatabaseRepositoryImpl.kt
@@ -56,6 +56,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
+import org.jellyfin.sdk.model.api.UserItemDataDto
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Provider
@@ -408,6 +409,23 @@ constructor(
 
     override suspend fun updateUserData(userData: AfinityUserDataDto) {
         userDataDao.updateUserData(userData)
+    }
+
+    override suspend fun patchUserDataLocally(
+        itemId: UUID,
+        userId: UUID,
+        serverId: String,
+        userData: UserItemDataDto,
+    ) {
+        userDataDao.patchUserDataLocally(
+            itemId = itemId,
+            userId = userId,
+            serverId = serverId,
+            isPlayed = userData.played ?: false,
+            positionTicks = userData.playbackPositionTicks ?: 0L,
+            isFavorite = userData.isFavorite ?: false,
+            isLiked = userData.likes ?: false,
+        )
     }
 
     override suspend fun deleteUserData(userId: UUID, itemId: UUID) {
@@ -775,7 +793,11 @@ constructor(
         return serverDatabaseDao.getSources(itemId)
     }
 
-    override suspend fun getItemMetadata(itemId: UUID, serverId: String, userId: String): ItemMetadataCacheEntity? {
+    override suspend fun getItemMetadata(
+        itemId: UUID,
+        serverId: String,
+        userId: String,
+    ): ItemMetadataCacheEntity? {
         return itemMetadataCacheDao.getMetadata(itemId, serverId, userId)
     }
 

--- a/app/src/main/java/com/makd/afinity/data/repository/playback/JellyfinPlaybackRepository.kt
+++ b/app/src/main/java/com/makd/afinity/data/repository/playback/JellyfinPlaybackRepository.kt
@@ -342,6 +342,7 @@ constructor(
                     serverId = serverId,
                     played = existingData?.played ?: false,
                     favorite = existingData?.favorite ?: false,
+                    likes = existingData?.likes ?: false,
                     playbackPositionTicks = positionTicks,
                     toBeSynced = true,
                     audioStreamIndex = audioStreamIndex ?: existingData?.audioStreamIndex,

--- a/app/src/main/java/com/makd/afinity/di/NetworkModule.kt
+++ b/app/src/main/java/com/makd/afinity/di/NetworkModule.kt
@@ -3,11 +3,11 @@ package com.makd.afinity.di
 import android.content.Context
 import com.makd.afinity.BuildConfig
 import com.makd.afinity.core.AppConstants
+import com.makd.afinity.data.manager.SessionManager
 import com.makd.afinity.data.network.AudiobookshelfApiService
 import com.makd.afinity.data.network.JellyseerrApiService
 import com.makd.afinity.data.network.MdbListApiService
 import com.makd.afinity.data.network.TmdbApiService
-import com.makd.afinity.data.manager.SessionManager
 import com.makd.afinity.data.repository.SecurePreferencesRepository
 import dagger.Module
 import dagger.Provides
@@ -180,9 +180,10 @@ object NetworkModule {
                             )
                         if (
                             sanitizedMessage.contains("ERROR") ||
-                                sanitizedMessage.contains("FAILED") ||
-                                sanitizedMessage.contains("-->") ||
-                                sanitizedMessage.contains("<--")
+                                sanitizedMessage.contains("FAILED")
+                        //                            ||
+                        //                                sanitizedMessage.contains("-->") ||
+                        //                                sanitizedMessage.contains("<--")
                         ) {
                             Timber.tag("Jellyfin-HTTP").d(sanitizedMessage)
                         }

--- a/app/src/main/java/com/makd/afinity/player/audiobookshelf/AudiobookshelfPlayer.kt
+++ b/app/src/main/java/com/makd/afinity/player/audiobookshelf/AudiobookshelfPlayer.kt
@@ -103,7 +103,8 @@ constructor(
             Timber.d("MediaController connected to Service")
             mediaController
         } catch (e: Exception) {
-            Timber.e(e, "Failed to connect MediaController")
+            Timber.e(e, "Failed to connect MediaController (Fix with AI)")
+            controllerFuture = null
             null
         }
     }
@@ -589,10 +590,13 @@ constructor(
             }
         }
 
-        mediaController?.stop()
-        mediaController?.clearMediaItems()
-
-        controllerFuture?.let { MediaController.releaseFuture(it) }
+        controllerFuture?.let { future ->
+            if (mediaController != null) {
+                MediaController.releaseFuture(future)
+            } else {
+                future.cancel(false)
+            }
+        }
         mediaController = null
         controllerFuture = null
 

--- a/app/src/main/java/com/makd/afinity/ui/favorites/FavoritesViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/favorites/FavoritesViewModel.kt
@@ -3,6 +3,7 @@ package com.makd.afinity.ui.favorites
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.makd.afinity.data.manager.MediaChangeManager
+import com.makd.afinity.data.manager.MediaChangeSource
 import com.makd.afinity.data.models.download.DownloadInfo
 import com.makd.afinity.data.models.media.AfinityBoxSet
 import com.makd.afinity.data.models.media.AfinityEpisode
@@ -16,22 +17,26 @@ import com.makd.afinity.data.repository.FieldSets
 import com.makd.afinity.data.repository.PreferencesRepository
 import com.makd.afinity.data.repository.download.DownloadRepository
 import com.makd.afinity.data.repository.media.MediaRepository
-import com.makd.afinity.util.NetworkConnectivityMonitor
 import com.makd.afinity.data.repository.userdata.UserDataRepository
 import com.makd.afinity.data.repository.watchlist.WatchlistRepository
 import com.makd.afinity.ui.item.delegates.ItemDownloadDelegate
 import com.makd.afinity.ui.item.delegates.ItemUserDataDelegate
+import com.makd.afinity.util.NetworkConnectivityMonitor
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
 
+@OptIn(FlowPreview::class)
 @HiltViewModel
 class FavoritesViewModel
 @Inject
@@ -51,7 +56,8 @@ constructor(
     private val _uiState = MutableStateFlow(FavoritesUiState())
 
     val canDownload: StateFlow<Boolean> =
-        preferencesRepository.getDownloadWifiOnlyFlow()
+        preferencesRepository
+            .getDownloadWifiOnlyFlow()
             .combine(networkMonitor.isOnWifiFlow) { wifiOnly, onWifi -> !wifiOnly || onWifi }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
     val uiState: StateFlow<FavoritesUiState> = _uiState.asStateFlow()
@@ -70,28 +76,49 @@ constructor(
     val selectedEpisodeDownloadInfo: StateFlow<DownloadInfo?> =
         _selectedEpisodeDownloadInfo.asStateFlow()
 
+    private val favoritesRefreshTrigger = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+
     init {
         viewModelScope.launch {
             appDataRepository.favoritesData.collect { data ->
-                _uiState.value = FavoritesUiState(
-                    movies = data.movies,
-                    shows = data.shows,
-                    seasons = data.seasons,
-                    episodes = data.episodes,
-                    boxSets = data.boxSets,
-                    channels = data.channels,
-                    people = data.people,
-                    isLoading = false,
-                    error = null,
-                )
+                _uiState.value =
+                    FavoritesUiState(
+                        movies = data.movies,
+                        shows = data.shows,
+                        seasons = data.seasons,
+                        episodes = data.episodes,
+                        boxSets = data.boxSets,
+                        channels = data.channels,
+                        people = data.people,
+                        isLoading = false,
+                        error = null,
+                    )
+            }
+        }
+        viewModelScope.launch {
+            favoritesRefreshTrigger.debounce(300L).collect {
+                Timber.d("WebSocket favorite changes settled. Syncing in-memory list...")
+                appDataRepository.reloadFavorites()
             }
         }
         viewModelScope.launch {
             mediaChangeManager.mediaChanges.collect { event ->
                 _selectedEpisode.value?.let { ep ->
-                    if (ep.id == event.itemId && event.updatedItem is AfinityEpisode) {
-                        _selectedEpisode.value = event.updatedItem
+                    if (ep.id == event.itemId) {
+                        val updatedEp =
+                            event.updatedItem as? AfinityEpisode
+                                ?: (mediaRepository.getItemById(event.itemId) as? AfinityEpisode)
+
+                        if (updatedEp != null) {
+                            _selectedEpisode.value = updatedEp
+                        }
                     }
+                }
+                if (
+                    event.source == MediaChangeSource.WEBSOCKET &&
+                        event.userData?.isFavorite != null
+                ) {
+                    favoritesRefreshTrigger.tryEmit(Unit)
                 }
             }
         }
@@ -99,7 +126,14 @@ constructor(
 
     fun loadFavorites() {
         viewModelScope.launch {
-            appDataRepository.reloadFavorites()
+            val currentData = _uiState.value
+            val hasData =
+                currentData.movies.isNotEmpty() ||
+                    currentData.shows.isNotEmpty() ||
+                    currentData.episodes.isNotEmpty()
+            if (!hasData) {
+                appDataRepository.reloadFavorites()
+            }
         }
     }
 
@@ -174,10 +208,14 @@ constructor(
                         userDataRepository.markUnwatched(episode.id)
                     } else {
                         userDataRepository.markWatched(episode.id)
-                }
+                    }
 
                 if (success) {
-                    mediaChangeManager.notifyItemChanged(episode.id, episode.seriesId, episode.seasonId)
+                    mediaChangeManager.notifyItemChanged(
+                        episode.id,
+                        episode.seriesId,
+                        episode.seasonId,
+                    )
                 } else {
                     _selectedEpisode.value = episode
                 }

--- a/app/src/main/java/com/makd/afinity/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/home/HomeViewModel.kt
@@ -50,15 +50,19 @@ import com.makd.afinity.util.NetworkConnectivityMonitor
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -70,9 +74,11 @@ import org.jellyfin.sdk.model.api.PersonKind.ACTOR
 import org.jellyfin.sdk.model.api.PersonKind.DIRECTOR
 import org.jellyfin.sdk.model.api.PersonKind.WRITER
 import timber.log.Timber
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
+@OptIn(FlowPreview::class)
 @HiltViewModel
 class HomeViewModel
 @Inject
@@ -111,14 +117,15 @@ constructor(
     private var cachedSpotlightPositions: List<Int> = emptyList()
 
     private val recommendationMutex = Mutex()
+    private val layoutRefreshTrigger = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
 
-    private var recommendationLoadingJob: kotlinx.coroutines.Job? = null
-    private var libraryContentReloadJob: kotlinx.coroutines.Job? = null
+    private var recommendationLoadingJob: Job? = null
+    private var libraryContentReloadJob: Job? = null
 
     private val renderedPeopleNames = mutableSetOf<String>()
-    private val renderedItemIds = mutableSetOf<java.util.UUID>()
-    private val renderedWatchedMovies = mutableSetOf<java.util.UUID>()
-    private val renderedStarringWatchedMovies = mutableSetOf<java.util.UUID>()
+    private val renderedItemIds = mutableSetOf<UUID>()
+    private val renderedWatchedMovies = mutableSetOf<UUID>()
+    private val renderedStarringWatchedMovies = mutableSetOf<UUID>()
     private val renderedActorNames = mutableSetOf<String>()
 
     init {
@@ -293,8 +300,11 @@ constructor(
 
         viewModelScope.launch {
             mediaChangeManager.mediaChanges.collect { event ->
-                val targetItem = event.parentItem ?: event.updatedItem ?: return@collect
-                Timber.d("HomeViewModel received media change for ${event.itemId}")
+                val targetItem =
+                    event.updatedItem
+                        ?: event.parentItem
+                        ?: mediaRepository.getItemById(event.itemId)
+                        ?: return@collect
                 updateItemInDynamicSections(targetItem)
             }
         }
@@ -311,6 +321,15 @@ constructor(
                         launch { loadUpcomingEpisodes() }
                     }
                     loadNewHomescreenSections()
+                }
+            }
+        }
+
+        viewModelScope.launch {
+            layoutRefreshTrigger.debounce(300L).collect {
+                Timber.d("UI Batch complete. Redrawing Homescreen sections.")
+                withContext(Dispatchers.Main) {
+                    updateCombinedSections(appDataRepository.combinedGenres.value)
                 }
             }
         }
@@ -850,7 +869,7 @@ constructor(
                 }
                 tasks.awaitAll()
             }
-            val seenIds = mutableSetOf<java.util.UUID>()
+            val seenIds = mutableSetOf<UUID>()
             val deduplicated =
                 loadedSpotlightSections.shuffled().mapNotNull { section ->
                     val uniqueItems = section.items.filter { seenIds.add(it.id) }.take(10)
@@ -1321,9 +1340,7 @@ constructor(
             loadedRecommendationSections.addAll(updatedSections)
             loadedSpotlightSections.clear()
             loadedSpotlightSections.addAll(updatedSpotlights)
-            withContext(Dispatchers.Main) {
-                updateCombinedSections(appDataRepository.combinedGenres.value)
-            }
+            layoutRefreshTrigger.tryEmit(Unit)
         }
     }
 

--- a/app/src/main/java/com/makd/afinity/ui/item/ItemDetailViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/item/ItemDetailViewModel.kt
@@ -12,6 +12,7 @@ import androidx.paging.map
 import com.makd.afinity.R
 import com.makd.afinity.data.database.entities.ItemMetadataCacheEntity
 import com.makd.afinity.data.manager.MediaChangeManager
+import com.makd.afinity.data.manager.MediaChangeSource
 import com.makd.afinity.data.manager.OfflineModeManager
 import com.makd.afinity.data.manager.PlaybackEvent
 import com.makd.afinity.data.manager.PlaybackStateManager
@@ -51,14 +52,17 @@ import com.makd.afinity.ui.item.delegates.ItemUserDataDelegate
 import com.makd.afinity.util.NetworkConnectivityMonitor
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -70,6 +74,7 @@ import java.util.UUID
 import javax.inject.Inject
 import kotlin.coroutines.cancellation.CancellationException
 
+@OptIn(FlowPreview::class)
 @HiltViewModel
 class ItemDetailViewModel
 @Inject
@@ -126,6 +131,7 @@ constructor(
 
     private val _selectedMediaSource = MutableStateFlow<MediaSourceOption?>(null)
     val selectedMediaSource = _selectedMediaSource.asStateFlow()
+    private val backgroundSyncTrigger = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
 
     fun selectMediaSource(source: MediaSourceOption) {
         _selectedMediaSource.value = source
@@ -142,6 +148,13 @@ constructor(
                 _uiState.value = _uiState.value.copy(containingBoxSets = boxSets)
             } catch (e: Exception) {
                 Timber.e(e, "Failed to load containing BoxSets in init")
+            }
+        }
+
+        viewModelScope.launch {
+            backgroundSyncTrigger.debounce(500L).collect {
+                Timber.d("Debounced background sync triggered for item: $itemId")
+                syncWithServerInBackground()
             }
         }
 
@@ -162,16 +175,23 @@ constructor(
 
         viewModelScope.launch {
             mediaChangeManager.mediaChanges.collect { event ->
-                val changedItem = event.updatedItem
+                val changedItem = event.updatedItem ?: mediaRepository.getItemById(event.itemId)
+                val resolvedSeriesId =
+                    event.seriesId
+                        ?: (changedItem as? AfinityEpisode)?.seriesId
+                        ?: (changedItem as? AfinitySeason)?.seriesId
+                val resolvedSeasonId = event.seasonId ?: (changedItem as? AfinityEpisode)?.seasonId
+
                 val isNextEpisode = _uiState.value.nextEpisode?.id == event.itemId
                 val isBoxSetItem = _uiState.value.boxSetItems.any { it.id == event.itemId }
                 val isChildUpdate =
                     _uiState.value.seasons.any { season ->
                         season.episodes.any { it.id == event.itemId } || season.id == event.itemId
                     }
-                val isDirectParentMatch = event.seriesId == itemId || event.seasonId == itemId
+                val isDirectParentMatch = resolvedSeriesId == itemId || resolvedSeasonId == itemId
                 val belongsToLoadedSeason =
-                    event.seasonId != null && _uiState.value.seasons.any { it.id == event.seasonId }
+                    resolvedSeasonId != null &&
+                        _uiState.value.seasons.any { it.id == resolvedSeasonId }
                 val belongsToCurrentItem =
                     when (changedItem) {
                         is AfinityEpisode ->
@@ -191,11 +211,98 @@ constructor(
 
                 if (isRelated) {
                     (changedItem as? AfinityEpisode)?.let { ep ->
-                        if (_episodeStatusUpdates.value[ep.id] != ep.played) {
+                        val currentStatus = _episodeStatusUpdates.value[ep.id]
+                        if (currentStatus != ep.played) {
                             _episodeStatusUpdates.value += (ep.id to ep.played)
+
+                            val currentSeasons = _uiState.value.seasons.toMutableList()
+                            val seasonIndex = currentSeasons.indexOfFirst { it.id == ep.seasonId }
+                            if (seasonIndex != -1) {
+                                val season = currentSeasons[seasonIndex]
+                                val offset = if (ep.played) -1 else 1
+                                val newCount =
+                                    ((season.unplayedItemCount ?: 0) + offset).coerceAtLeast(0)
+                                currentSeasons[seasonIndex] =
+                                    season.copy(unplayedItemCount = newCount)
+                                _uiState.value = _uiState.value.copy(seasons = currentSeasons)
+                            }
+
+                            val currentItem = _uiState.value.item
+                            if (currentItem is AfinityShow) {
+                                val offset = if (ep.played) -1 else 1
+                                val newCount =
+                                    ((currentItem.unplayedItemCount ?: 0) + offset).coerceAtLeast(0)
+                                _uiState.value =
+                                    _uiState.value.copy(
+                                        item = currentItem.copy(unplayedItemCount = newCount)
+                                    )
+                            }
                         }
                     }
-                    refreshFromCacheImmediate()
+
+                    (changedItem as? AfinitySeason)?.let { season ->
+                        val currentSeasons = _uiState.value.seasons.toMutableList()
+                        val index = currentSeasons.indexOfFirst { it.id == season.id }
+                        if (index != -1) {
+                            currentSeasons[index] = season
+                            _uiState.value = _uiState.value.copy(seasons = currentSeasons)
+                        }
+                    }
+
+                    (changedItem as? AfinityMovie)?.let { movie ->
+                        val currentBoxSets = _uiState.value.containingBoxSets.toMutableList()
+                        var boxSetChanged = false
+
+                        currentBoxSets.forEachIndexed { index, boxSet ->
+                            val isMovieInThisBoxSet =
+                                _uiState.value.boxSetItems.any { it.id == movie.id }
+
+                            if (isMovieInThisBoxSet) {
+                                val newCount =
+                                    (boxSet.unplayedItemCount ?: 1) - (if (movie.played) 1 else -1)
+                                currentBoxSets[index] =
+                                    boxSet.copy(unplayedItemCount = newCount.coerceAtLeast(0))
+                                boxSetChanged = true
+                            }
+                        }
+
+                        if (boxSetChanged) {
+                            _uiState.value = _uiState.value.copy(containingBoxSets = currentBoxSets)
+                        }
+                    }
+
+                    //                    (changedItem as? AfinityMovie)?.let { movie ->
+                    //                        val currentBoxSets =
+                    // _uiState.value.containingBoxSets.toMutableList()
+                    //                        var boxSetChanged = false
+                    //
+                    //                        currentBoxSets.forEachIndexed { index, boxSet ->
+                    //                            if (boxSet.id == movie.collectionId) {
+                    //                                val newCount =
+                    //                                    (boxSet.unplayedItemCount ?: 1) - (if
+                    // (movie.played) 1 else -1)
+                    //                                currentBoxSets[index] =
+                    //                                    boxSet.copy(unplayedItemCount =
+                    // newCount.coerceAtLeast(0))
+                    //                                boxSetChanged = true
+                    //                            }
+                    //                        }
+                    //
+                    //                        if (boxSetChanged) {
+                    //                            _uiState.value =
+                    // _uiState.value.copy(containingBoxSets = currentBoxSets)
+                    //                        }
+                    //                    }
+
+                    val skipNetwork =
+                        event.source == MediaChangeSource.WEBSOCKET ||
+                            event.source == MediaChangeSource.MANUAL
+
+                    refreshFromCacheImmediate(skipNetworkSync = skipNetwork)
+
+                    if (skipNetwork) {
+                        backgroundSyncTrigger.tryEmit(Unit)
+                    }
                 }
                 updateSimilarItemsOnSync(event.itemId)
             }
@@ -296,7 +403,7 @@ constructor(
         )
     }
 
-    private fun refreshFromCacheImmediate() {
+    private fun refreshFromCacheImmediate(skipNetworkSync: Boolean = false) {
         viewModelScope.launch {
             try {
                 val cachedItem = mediaRepository.getItemById(itemId)
@@ -331,7 +438,10 @@ constructor(
                         is AfinityBoxSet -> loadBoxSetItems(cachedItem.id)
                     }
                 }
-                launch { syncWithServerInBackground() }
+
+                if (!skipNetworkSync) {
+                    launch { syncWithServerInBackground() }
+                }
             } catch (e: Exception) {
                 Timber.e(e, "Failed to refresh from cache")
             }

--- a/app/src/main/java/com/makd/afinity/ui/library/LibraryContentViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/library/LibraryContentViewModel.kt
@@ -10,6 +10,7 @@ import androidx.paging.filter
 import androidx.paging.map
 import com.makd.afinity.R
 import com.makd.afinity.data.manager.MediaChangeManager
+import com.makd.afinity.data.manager.MediaChangeSource
 import com.makd.afinity.data.models.common.CollectionType
 import com.makd.afinity.data.models.common.SortBy
 import com.makd.afinity.data.models.media.AfinityItem
@@ -18,11 +19,14 @@ import com.makd.afinity.data.repository.PreferencesRepository
 import com.makd.afinity.data.repository.media.MediaRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -38,6 +42,7 @@ enum class FilterType {
     FAVORITES,
 }
 
+@OptIn(FlowPreview::class)
 @HiltViewModel
 class LibraryContentViewModel
 @Inject
@@ -65,6 +70,8 @@ constructor(
     val uiState: StateFlow<LibraryContentUiState> = _uiState.asStateFlow()
 
     private val _itemUpdates = MutableStateFlow<Map<UUID, AfinityItem>>(emptyMap())
+    private val pendingUpdates = mutableMapOf<UUID, AfinityItem>()
+    private val libraryUpdateTrigger = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
 
     private fun applyUpdatesToPagingFlow(
         baseFlow: Flow<PagingData<AfinityItem>>
@@ -120,9 +127,29 @@ constructor(
             }
         }
         viewModelScope.launch {
+            libraryUpdateTrigger.debounce(300L).collect {
+                if (pendingUpdates.isNotEmpty()) {
+                    _itemUpdates.value += pendingUpdates
+                    pendingUpdates.clear()
+                    Timber.d("Applied batched PagingData updates to Library")
+                }
+            }
+        }
+
+        viewModelScope.launch {
             mediaChangeManager.mediaChanges.collect { event ->
-                val targetItem = event.parentItem ?: event.updatedItem ?: return@collect
-                _itemUpdates.value += (targetItem.id to targetItem)
+                val targetItem =
+                    event.parentItem
+                        ?: event.updatedItem
+                        ?: mediaRepository.getItemById(event.itemId)
+                        ?: return@collect
+
+                if (event.source == MediaChangeSource.WEBSOCKET) {
+                    pendingUpdates[targetItem.id] = targetItem
+                    libraryUpdateTrigger.tryEmit(Unit)
+                } else {
+                    _itemUpdates.value += (targetItem.id to targetItem)
+                }
             }
         }
     }

--- a/app/src/main/java/com/makd/afinity/ui/livetv/LiveTvViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/livetv/LiveTvViewModel.kt
@@ -11,13 +11,16 @@ import com.makd.afinity.ui.livetv.models.ProgramWithChannel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -27,6 +30,7 @@ import java.time.temporal.ChronoUnit
 import java.util.UUID
 import javax.inject.Inject
 
+@OptIn(FlowPreview::class)
 @HiltViewModel
 class LiveTvViewModel
 @Inject
@@ -45,8 +49,13 @@ constructor(
 
     private var refreshJob: Job? = null
 
+    private val tabSwitchTrigger = MutableSharedFlow<LiveTvTab>(extraBufferCapacity = 1)
+
     init {
         checkLiveTvAccess()
+        viewModelScope.launch {
+            tabSwitchTrigger.debounce(200L).collect { tab -> refreshCurrentTabData(tab) }
+        }
     }
 
     fun onLetterSelected(letter: String) {
@@ -275,17 +284,7 @@ constructor(
 
     fun selectTab(tab: LiveTvTab) {
         _uiState.update { it.copy(selectedTab = tab) }
-        when (tab) {
-            LiveTvTab.HOME -> loadCategorizedPrograms()
-            LiveTvTab.GUIDE -> loadEpgData()
-            LiveTvTab.CHANNELS -> {
-                if (allChannelsCache.isEmpty()) {
-                    loadChannels()
-                } else {
-                    applyFilterToCache(_selectedLetter.value)
-                }
-            }
-        }
+        tabSwitchTrigger.tryEmit(tab)
     }
 
     fun jumpToNow() {
@@ -305,15 +304,15 @@ constructor(
         refreshJob?.cancel()
         refreshJob = viewModelScope.launch {
             while (isActive) {
-                delay(60000L)
-                refreshCurrentTabData()
+                delay(60_000L)
+                refreshCurrentTabData(_uiState.value.selectedTab)
             }
         }
     }
 
-    private suspend fun refreshCurrentTabData() {
+    private suspend fun refreshCurrentTabData(tab: LiveTvTab) {
         try {
-            when (_uiState.value.selectedTab) {
+            when (tab) {
                 LiveTvTab.HOME -> loadCategorizedPrograms()
                 LiveTvTab.GUIDE -> loadEpgData()
                 LiveTvTab.CHANNELS -> {
@@ -323,7 +322,7 @@ constructor(
                 }
             }
         } catch (e: Exception) {
-            Timber.w(e, "Failed to refresh tab data")
+            Timber.w(e, "Failed to refresh tab data for $tab")
         }
     }
 

--- a/app/src/main/java/com/makd/afinity/ui/person/PersonViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/person/PersonViewModel.kt
@@ -5,6 +5,9 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.makd.afinity.R
+import com.makd.afinity.data.manager.MediaChangeManager
+import com.makd.afinity.data.manager.MediaChangeSource
+import com.makd.afinity.data.models.media.AfinityItem
 import com.makd.afinity.data.models.media.AfinityMovie
 import com.makd.afinity.data.models.media.AfinityPersonDetail
 import com.makd.afinity.data.models.media.AfinityShow
@@ -13,15 +16,19 @@ import com.makd.afinity.data.repository.media.MediaRepository
 import com.makd.afinity.data.repository.userdata.UserDataRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.util.UUID
 import javax.inject.Inject
 
+@OptIn(FlowPreview::class)
 @HiltViewModel
 class PersonViewModel
 @Inject
@@ -30,6 +37,7 @@ constructor(
     private val mediaRepository: MediaRepository,
     private val appDataRepository: AppDataRepository,
     private val userDataRepository: UserDataRepository,
+    private val mediaChangeManager: MediaChangeManager,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
@@ -45,6 +53,9 @@ constructor(
     private val _uiState = MutableStateFlow(PersonUiState())
     val uiState: StateFlow<PersonUiState> = _uiState.asStateFlow()
 
+    private val pendingItemUpdates = mutableMapOf<UUID, AfinityItem>()
+    private val personListUpdateTrigger = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+
     init {
         viewModelScope.launch {
             appDataRepository.isInitialDataLoaded.collect { isLoaded ->
@@ -52,6 +63,66 @@ constructor(
                     loadPersonDetails()
                 } else {
                     _uiState.update { PersonUiState() }
+                }
+            }
+        }
+        viewModelScope.launch {
+            personListUpdateTrigger.debounce(300L).collect {
+                if (pendingItemUpdates.isEmpty()) return@collect
+
+                val currentMovies = _uiState.value.movies
+                val currentShows = _uiState.value.shows
+                var hasChanges = false
+
+                val newMovies = currentMovies.map { movie ->
+                    pendingItemUpdates[movie.id]?.also { hasChanges = true } as? AfinityMovie
+                        ?: movie
+                }
+
+                val newShows = currentShows.map { show ->
+                    pendingItemUpdates[show.id]?.also { hasChanges = true } as? AfinityShow ?: show
+                }
+
+                if (hasChanges) {
+                    _uiState.update { it.copy(movies = newMovies, shows = newShows) }
+                    Timber.d("Applied batched updates to Person screen lists")
+                }
+                pendingItemUpdates.clear()
+            }
+        }
+        viewModelScope.launch {
+            mediaChangeManager.mediaChanges.collect { event ->
+                val targetItem =
+                    event.updatedItem
+                        ?: event.parentItem
+                        ?: mediaRepository.getItemById(event.itemId)
+                        ?: return@collect
+
+                if (event.source == MediaChangeSource.WEBSOCKET) {
+                    pendingItemUpdates[targetItem.id] = targetItem
+                    personListUpdateTrigger.tryEmit(Unit)
+                } else {
+                    val currentMovies = _uiState.value.movies
+                    val currentShows = _uiState.value.shows
+                    var hasChanges = false
+
+                    val newMovies = currentMovies.map { movie ->
+                        if (movie.id == targetItem.id) {
+                            hasChanges = true
+                            targetItem as? AfinityMovie ?: movie
+                        } else movie
+                    }
+
+                    val newShows = currentShows.map { show ->
+                        if (show.id == targetItem.id) {
+                            hasChanges = true
+                            targetItem as? AfinityShow ?: show
+                        } else show
+                    }
+
+                    if (hasChanges) {
+                        _uiState.update { it.copy(movies = newMovies, shows = newShows) }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/makd/afinity/ui/search/GenreResultsViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/search/GenreResultsViewModel.kt
@@ -11,23 +11,29 @@ import androidx.paging.PagingState
 import androidx.paging.cachedIn
 import androidx.paging.map
 import com.makd.afinity.data.manager.MediaChangeManager
+import com.makd.afinity.data.manager.MediaChangeSource
 import com.makd.afinity.data.models.extensions.toAfinityItem
 import com.makd.afinity.data.models.media.AfinityItem
 import com.makd.afinity.data.repository.AppDataRepository
 import com.makd.afinity.data.repository.media.MediaRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import java.util.UUID
 import javax.inject.Inject
 
+@OptIn(FlowPreview::class)
 @HiltViewModel
 class GenreResultsViewModel
 @Inject
@@ -51,6 +57,9 @@ constructor(
 
     private val _itemUpdates = MutableStateFlow<Map<UUID, AfinityItem>>(emptyMap())
 
+    private val pendingUpdates = mutableMapOf<UUID, AfinityItem>()
+    private val genreUpdateTrigger = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+
     private fun applyUpdatesToPagingFlow(
         baseFlow: Flow<PagingData<AfinityItem>>
     ): Flow<PagingData<AfinityItem>> {
@@ -64,9 +73,28 @@ constructor(
 
     init {
         viewModelScope.launch {
+            genreUpdateTrigger.debounce(300L).collect {
+                if (pendingUpdates.isNotEmpty()) {
+                    _itemUpdates.value += pendingUpdates
+                    pendingUpdates.clear()
+                    Timber.d("Applied batched PagingData updates")
+                }
+            }
+        }
+
+        viewModelScope.launch {
             mediaChangeManager.mediaChanges.collect { event ->
-                val targetItem = event.parentItem ?: event.updatedItem ?: return@collect
-                _itemUpdates.value += (targetItem.id to targetItem)
+                val targetItem =
+                    event.parentItem
+                        ?: event.updatedItem
+                        ?: mediaRepository.getItemById(event.itemId)
+                        ?: return@collect
+                if (event.source == MediaChangeSource.WEBSOCKET) {
+                    pendingUpdates[targetItem.id] = targetItem
+                    genreUpdateTrigger.tryEmit(Unit)
+                } else {
+                    _itemUpdates.value += (targetItem.id to targetItem)
+                }
             }
         }
     }

--- a/app/src/main/java/com/makd/afinity/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/search/SearchViewModel.kt
@@ -3,6 +3,7 @@ package com.makd.afinity.ui.search
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.makd.afinity.data.manager.MediaChangeManager
+import com.makd.afinity.data.manager.MediaChangeSource
 import com.makd.afinity.data.models.audiobookshelf.LibraryItem
 import com.makd.afinity.data.models.common.CollectionType
 import com.makd.afinity.data.models.common.SortBy
@@ -22,7 +23,6 @@ import com.makd.afinity.data.models.media.AfinityCollection
 import com.makd.afinity.data.models.media.AfinityEpisode
 import com.makd.afinity.data.models.media.AfinityItem
 import com.makd.afinity.data.models.media.AfinityMovie
-import com.makd.afinity.data.models.media.AfinitySeason
 import com.makd.afinity.data.models.media.AfinityShow
 import com.makd.afinity.data.models.media.toAfinityEpisode
 import com.makd.afinity.data.repository.AppDataRepository
@@ -34,10 +34,10 @@ import com.makd.afinity.data.repository.PreferencesRepository
 import com.makd.afinity.data.repository.auth.AuthRepository
 import com.makd.afinity.data.repository.download.DownloadRepository
 import com.makd.afinity.data.repository.media.MediaRepository
-import com.makd.afinity.util.NetworkConnectivityMonitor
 import com.makd.afinity.data.repository.userdata.UserDataRepository
 import com.makd.afinity.ui.item.delegates.ItemDownloadDelegate
 import com.makd.afinity.ui.item.delegates.ItemUserDataDelegate
+import com.makd.afinity.util.NetworkConnectivityMonitor
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -50,17 +50,18 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
 import timber.log.Timber
+import java.util.UUID
 import javax.inject.Inject
 
 @OptIn(FlowPreview::class)
@@ -86,7 +87,8 @@ constructor(
     private val _uiState = MutableStateFlow(SearchUiState())
 
     val canDownload: StateFlow<Boolean> =
-        preferencesRepository.getDownloadWifiOnlyFlow()
+        preferencesRepository
+            .getDownloadWifiOnlyFlow()
             .combine(networkMonitor.isOnWifiFlow) { wifiOnly, onWifi -> !wifiOnly || onWifi }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
     val uiState: StateFlow<SearchUiState> = _uiState.asStateFlow()
@@ -116,6 +118,8 @@ constructor(
     private var audiobookshelfSearchJob: Job? = null
 
     private val searchQueryFlow = MutableSharedFlow<String>(extraBufferCapacity = 1)
+    private val pendingItemUpdates = mutableMapOf<UUID, AfinityItem>()
+    private val searchResultsUpdateTrigger = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
 
     init {
         viewModelScope.launch {
@@ -155,9 +159,42 @@ constructor(
         }
 
         viewModelScope.launch {
+            searchResultsUpdateTrigger.debounce(300L).collect {
+                if (pendingItemUpdates.isEmpty()) return@collect
+
+                val currentResults = _uiState.value.searchResults
+                var hasChanges = false
+
+                val newResults = currentResults.map { item ->
+                    pendingItemUpdates[item.id]?.also { hasChanges = true } ?: item
+                }
+
+                if (hasChanges) {
+                    _uiState.update { it.copy(searchResults = newResults) }
+                    Timber.d("Applied ${pendingItemUpdates.size} background search updates.")
+                }
+                pendingItemUpdates.clear()
+            }
+        }
+        viewModelScope.launch {
             mediaChangeManager.mediaChanges.collect { event ->
-                event.updatedItem?.let { updateItemInSearchResults(it) }
-                event.parentItem?.let { updateItemInSearchResults(it) }
+                val targetItem =
+                    event.updatedItem
+                        ?: event.parentItem
+                        ?: mediaRepository.getItemById(event.itemId)
+                        ?: return@collect
+
+                _selectedEpisode.value?.let { ep ->
+                    if (ep.id == event.itemId && targetItem is AfinityEpisode) {
+                        _selectedEpisode.value = targetItem
+                    }
+                }
+                if (event.source == MediaChangeSource.WEBSOCKET) {
+                    pendingItemUpdates[targetItem.id] = targetItem
+                    searchResultsUpdateTrigger.tryEmit(Unit)
+                } else {
+                    updateItemInSearchResults(targetItem)
+                }
             }
         }
     }
@@ -393,79 +430,73 @@ constructor(
                 else -> listOf("MOVIE", "SERIES", "EPISODE", "BOX_SET")
             }
 
-        searchJob =
-            viewModelScope.launch {
-                try {
-                    _uiState.value = _uiState.value.copy(isSearching = true)
-                    val results =
-                        mediaRepository.getItems(
-                            parentId = selectedLibrary?.id,
-                            searchTerm = query,
-                            includeItemTypes = itemTypes,
-                            limit = 50,
-                            sortBy = SortBy.NAME,
-                            sortDescending = false,
-                            fields = FieldSets.SEARCH_RESULTS,
-                        )
+        searchJob = viewModelScope.launch {
+            try {
+                _uiState.value = _uiState.value.copy(isSearching = true)
+                val results =
+                    mediaRepository.getItems(
+                        parentId = selectedLibrary?.id,
+                        searchTerm = query,
+                        includeItemTypes = itemTypes,
+                        limit = 50,
+                        sortBy = SortBy.NAME,
+                        sortDescending = false,
+                        fields = FieldSets.SEARCH_RESULTS,
+                    )
 
-                    val afinityItems =
-                        withContext(Dispatchers.Default) {
-                            yield()
+                val afinityItems =
+                    withContext(Dispatchers.Default) {
+                        yield()
 
-                            val mappedItems =
-                                results.items
-                                    ?.filter {
-                                        it.locationType !=
-                                            org.jellyfin.sdk.model.api.LocationType.VIRTUAL
-                                    }
-                                    ?.mapNotNull { baseItemDto ->
-                                        try {
-                                            val item =
-                                                baseItemDto.toAfinityItem(
-                                                    mediaRepository.getBaseUrl()
-                                                )
-                                            when (item) {
-                                                is AfinityMovie,
-                                                is AfinityShow,
-                                                is AfinityEpisode,
-                                                is AfinityBoxSet -> item
-                                                else -> null
-                                            }
-                                        } catch (e: Exception) {
-                                            Timber.w(
-                                                e,
-                                                "Failed to convert item: ${baseItemDto.name}",
-                                            )
-                                            null
-                                        }
-                                    } ?: emptyList()
-
-                            yield()
-
-                            mappedItems.sortedBy { item ->
-                                val name = item.name.lowercase()
-                                val queryLower = query.lowercase()
-                                when {
-                                    name == queryLower -> 0
-                                    name.startsWith(queryLower) -> 1
-                                    name.contains(queryLower) -> 2
-                                    else -> 3
+                        val mappedItems =
+                            results.items
+                                ?.filter {
+                                    it.locationType !=
+                                        org.jellyfin.sdk.model.api.LocationType.VIRTUAL
                                 }
+                                ?.mapNotNull { baseItemDto ->
+                                    try {
+                                        val item =
+                                            baseItemDto.toAfinityItem(mediaRepository.getBaseUrl())
+                                        when (item) {
+                                            is AfinityMovie,
+                                            is AfinityShow,
+                                            is AfinityEpisode,
+                                            is AfinityBoxSet -> item
+                                            else -> null
+                                        }
+                                    } catch (e: Exception) {
+                                        Timber.w(e, "Failed to convert item: ${baseItemDto.name}")
+                                        null
+                                    }
+                                } ?: emptyList()
+
+                        yield()
+
+                        mappedItems.sortedBy { item ->
+                            val name = item.name.lowercase()
+                            val queryLower = query.lowercase()
+                            when {
+                                name == queryLower -> 0
+                                name.startsWith(queryLower) -> 1
+                                name.contains(queryLower) -> 2
+                                else -> 3
                             }
                         }
+                    }
 
-                    _uiState.value =
-                        _uiState.value.copy(searchResults = afinityItems, isSearching = false)
+                _uiState.value =
+                    _uiState.value.copy(searchResults = afinityItems, isSearching = false)
 
-                    Timber.d("Search completed: ${afinityItems.size} results for '$query'")
-                } catch (e: Exception) {
-                    if (e is CancellationException) throw e
+                Timber.d("Search completed: ${afinityItems.size} results for '$query'")
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
 
-                    Timber.e(e, "Failed to perform search")
-                    _uiState.value =
-                        _uiState.value.copy(searchResults = emptyList(), isSearching = false)
-                }
+                Timber.e(e, "Failed to perform search")
+                _uiState.value =
+                    _uiState.value.copy(searchResults = emptyList(), isSearching = false)
             }
+        }
     }
 
     fun clearSearch() {
@@ -551,76 +582,69 @@ constructor(
         if (query.isEmpty()) return
 
         audiobookshelfSearchJob?.cancel()
-        audiobookshelfSearchJob =
-            viewModelScope.launch {
-                try {
-                    _uiState.update { it.copy(isAudiobookshelfSearching = true) }
+        audiobookshelfSearchJob = viewModelScope.launch {
+            try {
+                _uiState.update { it.copy(isAudiobookshelfSearching = true) }
 
-                    var libraries = audiobookshelfRepository.getLibrariesFlow().first()
-                    if (libraries.isEmpty()) {
-                        Timber.d("No cached libraries, refreshing from server")
-                        libraries =
-                            audiobookshelfRepository.refreshLibraries().getOrDefault(emptyList())
-                    }
-
-                    Timber.d(
-                        "Searching ${libraries.size} libraries: ${libraries.map { "${it.name}(${it.id})" }}"
-                    )
-
-                    val results =
-                        libraries
-                            .map { library ->
-                                async {
-                                    audiobookshelfRepository
-                                        .searchLibrary(library.id, query)
-                                        .onSuccess { response ->
-                                            Timber.d(
-                                                "Library '${library.name}': ${response.book?.size ?: 0} books, ${response.podcast?.size ?: 0} podcasts"
-                                            )
-                                        }
-                                        .onFailure {
-                                            Timber.w(
-                                                it,
-                                                "Search failed for library ${library.name}",
-                                            )
-                                        }
-                                        .getOrNull()
-                                }
-                            }
-                            .awaitAll()
-                            .filterNotNull()
-
-                    val items =
-                        withContext(Dispatchers.Default) {
-                            results
-                                .flatMap { response ->
-                                    val books = response.book?.map { it.libraryItem } ?: emptyList()
-                                    val podcasts =
-                                        response.podcast?.map { it.libraryItem } ?: emptyList()
-                                    books + podcasts
-                                }
-                                .distinctBy { it.id }
-                        }
-
-                    _uiState.update {
-                        it.copy(
-                            audiobookshelfSearchResults = items,
-                            isAudiobookshelfSearching = false,
-                        )
-                    }
-                    Timber.d("Audiobookshelf search completed: ${items.size} results for '$query'")
-                } catch (e: Exception) {
-                    if (e is CancellationException) throw e
-
-                    _uiState.update {
-                        it.copy(
-                            audiobookshelfSearchResults = emptyList(),
-                            isAudiobookshelfSearching = false,
-                        )
-                    }
-                    Timber.e(e, "Error during Audiobookshelf search")
+                var libraries = audiobookshelfRepository.getLibrariesFlow().first()
+                if (libraries.isEmpty()) {
+                    Timber.d("No cached libraries, refreshing from server")
+                    libraries =
+                        audiobookshelfRepository.refreshLibraries().getOrDefault(emptyList())
                 }
+
+                Timber.d(
+                    "Searching ${libraries.size} libraries: ${libraries.map { "${it.name}(${it.id})" }}"
+                )
+
+                val results =
+                    libraries
+                        .map { library ->
+                            async {
+                                audiobookshelfRepository
+                                    .searchLibrary(library.id, query)
+                                    .onSuccess { response ->
+                                        Timber.d(
+                                            "Library '${library.name}': ${response.book?.size ?: 0} books, ${response.podcast?.size ?: 0} podcasts"
+                                        )
+                                    }
+                                    .onFailure {
+                                        Timber.w(it, "Search failed for library ${library.name}")
+                                    }
+                                    .getOrNull()
+                            }
+                        }
+                        .awaitAll()
+                        .filterNotNull()
+
+                val items =
+                    withContext(Dispatchers.Default) {
+                        results
+                            .flatMap { response ->
+                                val books = response.book?.map { it.libraryItem } ?: emptyList()
+                                val podcasts =
+                                    response.podcast?.map { it.libraryItem } ?: emptyList()
+                                books + podcasts
+                            }
+                            .distinctBy { it.id }
+                    }
+
+                _uiState.update {
+                    it.copy(audiobookshelfSearchResults = items, isAudiobookshelfSearching = false)
+                }
+                Timber.d("Audiobookshelf search completed: ${items.size} results for '$query'")
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+
+                _uiState.update {
+                    it.copy(
+                        audiobookshelfSearchResults = emptyList(),
+                        isAudiobookshelfSearching = false,
+                    )
+                }
+                Timber.e(e, "Error during Audiobookshelf search")
             }
+        }
     }
 
     fun performJellyseerrSearch() {
@@ -628,51 +652,45 @@ constructor(
         if (query.isEmpty()) return
 
         jellyseerrSearchJob?.cancel()
-        jellyseerrSearchJob =
-            viewModelScope.launch {
-                try {
-                    _uiState.update { it.copy(isJellyseerrSearching = true) }
-                    jellyseerrRepository
-                        .findMediaByName(query)
-                        .fold(
-                            onSuccess = { results ->
-                                val filteredResults =
-                                    withContext(Dispatchers.Default) {
-                                        results.filter { it.getMediaType() != null }
-                                    }
-
-                                _uiState.update {
-                                    it.copy(
-                                        jellyseerrSearchResults = filteredResults,
-                                        isJellyseerrSearching = false,
-                                    )
+        jellyseerrSearchJob = viewModelScope.launch {
+            try {
+                _uiState.update { it.copy(isJellyseerrSearching = true) }
+                jellyseerrRepository
+                    .findMediaByName(query)
+                    .fold(
+                        onSuccess = { results ->
+                            val filteredResults =
+                                withContext(Dispatchers.Default) {
+                                    results.filter { it.getMediaType() != null }
                                 }
-                                Timber.d(
-                                    "Jellyseerr search completed: ${filteredResults.size} results"
+
+                            _uiState.update {
+                                it.copy(
+                                    jellyseerrSearchResults = filteredResults,
+                                    isJellyseerrSearching = false,
                                 )
-                            },
-                            onFailure = { error ->
-                                _uiState.update {
-                                    it.copy(
-                                        jellyseerrSearchResults = emptyList(),
-                                        isJellyseerrSearching = false,
-                                    )
-                                }
-                                Timber.e(error, "Jellyseerr search failed")
-                            },
-                        )
-                } catch (e: Exception) {
-                    if (e is CancellationException) throw e
+                            }
+                            Timber.d("Jellyseerr search completed: ${filteredResults.size} results")
+                        },
+                        onFailure = { error ->
+                            _uiState.update {
+                                it.copy(
+                                    jellyseerrSearchResults = emptyList(),
+                                    isJellyseerrSearching = false,
+                                )
+                            }
+                            Timber.e(error, "Jellyseerr search failed")
+                        },
+                    )
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
 
-                    _uiState.update {
-                        it.copy(
-                            jellyseerrSearchResults = emptyList(),
-                            isJellyseerrSearching = false,
-                        )
-                    }
-                    Timber.e(e, "Error during Jellyseerr search")
+                _uiState.update {
+                    it.copy(jellyseerrSearchResults = emptyList(), isJellyseerrSearching = false)
                 }
+                Timber.e(e, "Error during Jellyseerr search")
             }
+        }
     }
 
     fun showRequestDialog(

--- a/app/src/main/java/com/makd/afinity/ui/watchlist/WatchlistViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/watchlist/WatchlistViewModel.kt
@@ -3,6 +3,7 @@ package com.makd.afinity.ui.watchlist
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.makd.afinity.data.manager.MediaChangeManager
+import com.makd.afinity.data.manager.MediaChangeSource
 import com.makd.afinity.data.models.download.DownloadInfo
 import com.makd.afinity.data.models.media.AfinityBoxSet
 import com.makd.afinity.data.models.media.AfinityEpisode
@@ -16,22 +17,26 @@ import com.makd.afinity.data.repository.FieldSets
 import com.makd.afinity.data.repository.PreferencesRepository
 import com.makd.afinity.data.repository.download.DownloadRepository
 import com.makd.afinity.data.repository.media.MediaRepository
-import com.makd.afinity.util.NetworkConnectivityMonitor
 import com.makd.afinity.data.repository.userdata.UserDataRepository
 import com.makd.afinity.data.repository.watchlist.WatchlistRepository
 import com.makd.afinity.ui.item.delegates.ItemDownloadDelegate
 import com.makd.afinity.ui.item.delegates.ItemUserDataDelegate
+import com.makd.afinity.util.NetworkConnectivityMonitor
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
 
+@OptIn(FlowPreview::class)
 @HiltViewModel
 class WatchlistViewModel
 @Inject
@@ -51,7 +56,8 @@ constructor(
     private val _uiState = MutableStateFlow(WatchlistUiState())
 
     val canDownload: StateFlow<Boolean> =
-        preferencesRepository.getDownloadWifiOnlyFlow()
+        preferencesRepository
+            .getDownloadWifiOnlyFlow()
             .combine(networkMonitor.isOnWifiFlow) { wifiOnly, onWifi -> !wifiOnly || onWifi }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
     val uiState: StateFlow<WatchlistUiState> = _uiState.asStateFlow()
@@ -70,26 +76,44 @@ constructor(
     val selectedEpisodeDownloadInfo: StateFlow<DownloadInfo?> =
         _selectedEpisodeDownloadInfo.asStateFlow()
 
+    private val watchlistRefreshTrigger = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+
     init {
         viewModelScope.launch {
             appDataRepository.watchlistData.collect { data ->
-                _uiState.value = WatchlistUiState(
-                    boxSets = data.boxSets,
-                    movies = data.movies,
-                    shows = data.shows,
-                    seasons = data.seasons,
-                    episodes = data.episodes,
-                    isLoading = false,
-                    error = null,
-                )
+                _uiState.value =
+                    WatchlistUiState(
+                        boxSets = data.boxSets,
+                        movies = data.movies,
+                        shows = data.shows,
+                        seasons = data.seasons,
+                        episodes = data.episodes,
+                        isLoading = false,
+                        error = null,
+                    )
+            }
+        }
+        viewModelScope.launch {
+            watchlistRefreshTrigger.debounce(300L).collect {
+                Timber.d("WebSocket watchlist changes settled. Syncing in-memory list...")
+                appDataRepository.reloadWatchlist()
             }
         }
         viewModelScope.launch {
             mediaChangeManager.mediaChanges.collect { event ->
                 _selectedEpisode.value?.let { ep ->
-                    if (ep.id == event.itemId && event.updatedItem is AfinityEpisode) {
-                        _selectedEpisode.value = event.updatedItem
+                    if (ep.id == event.itemId) {
+                        val updatedEp =
+                            event.updatedItem as? AfinityEpisode
+                                ?: (mediaRepository.getItemById(event.itemId) as? AfinityEpisode)
+
+                        if (updatedEp != null) {
+                            _selectedEpisode.value = updatedEp
+                        }
                     }
+                }
+                if (event.source == MediaChangeSource.WEBSOCKET && event.userData?.likes != null) {
+                    watchlistRefreshTrigger.tryEmit(Unit)
                 }
             }
         }
@@ -97,7 +121,15 @@ constructor(
 
     fun loadWatchlist() {
         viewModelScope.launch {
-            appDataRepository.reloadWatchlist()
+            val currentData = _uiState.value
+            val hasData =
+                currentData.movies.isNotEmpty() ||
+                    currentData.shows.isNotEmpty() ||
+                    currentData.episodes.isNotEmpty() ||
+                    currentData.boxSets.isNotEmpty()
+            if (!hasData) {
+                appDataRepository.reloadWatchlist()
+            }
         }
     }
 
@@ -172,10 +204,14 @@ constructor(
                         userDataRepository.markUnwatched(episode.id)
                     } else {
                         userDataRepository.markWatched(episode.id)
-                }
+                    }
 
                 if (success) {
-                    mediaChangeManager.notifyItemChanged(episode.id, episode.seriesId, episode.seasonId)
+                    mediaChangeManager.notifyItemChanged(
+                        episode.id,
+                        episode.seriesId,
+                        episode.seasonId,
+                    )
                 } else {
                     _selectedEpisode.value = episode
                 }


### PR DESCRIPTION
This commit introduces a debouncing mechanism for media and user data updates to improve UI performance and reduce jank during high-frequency WebSocket traffic. It also adds a new `likes` field to the user data schema to support watchlist functionality and refactors local database patching.

### Key Changes:

*   **UI Performance & Batching**:
    *   **ViewModel Debouncing**: Implemented `MutableSharedFlow` triggers with `debounce` (300ms–500ms) in `HomeViewModel`, `SearchViewModel`, `ItemDetailViewModel`, `LibraryContentViewModel`, and `GenreResultsViewModel`. This batches incoming WebSocket updates into single UI state changes instead of triggering a recomposition for every individual item update.
    *   **Live TV Optimization (`LiveTvViewModel.kt`)**: Added a `tabSwitchTrigger` with a 200ms debounce to prevent rapid-fire data reloading when quickly switching between Home, Guide, and Channel tabs.
    *   **Home Screen Refresh**: Introduced `layoutRefreshTrigger` in `HomeViewModel` to consolidate dynamic section updates and avoid redundant layout calculations.

*   **Data & Persistence**:
    *   **Database Schema (`AfinityDatabase.kt`, `DatabaseMigrations.kt`)**: Bumped database version to `44` and added a migration to include the `likes` column in the `userdata` table.
    *   **Local Patching (`UserDataDao.kt`, `DatabaseRepository.kt`)**: Added `patchUserDataLocally` to allow direct updates to specific fields (played, favorite, likes, position) in the local database without requiring a full metadata refresh.
    *   **Media Change Management (`MediaChangeManager.kt`)**: Refactored `applyUserDataChangesBatch` to use the new local patching mechanism. Introduced a 1-second debounce for refreshing "Next Up" and "Continue Watching" sections after WebSocket syncs finish.

*   **Item Detail Enhancements (`ItemDetailViewModel.kt`)**:
    *   Implemented manual unplayed count arithmetic in the UI state for Episodes and Seasons to provide immediate visual feedback upon status changes while a background sync is pending.
    *   Added `backgroundSyncTrigger` to debounce network synchronization after local state updates.

*   **Player & Library Fixes**:
    *   **Audiobookshelf (`AudiobookshelfPlayer.kt`)**: Improved `MediaController` release logic by properly canceling the `controllerFuture` to prevent potential leaks or crashes during rapid playback lifecycle changes.
    *   **Favorites & Watchlist**: Refined `loadFavorites` and `loadWatchlist` in their respective ViewModels to prevent unnecessary reloads if data is already present in the UI state.
    *   **Logging**: Reduced verbosity in `NetworkModule.kt` by filtering out standard HTTP request/response headers from the logs.