### PR TITLE
fix: respect selected sourceId when downloading

### DIFF
--- a/app/src/main/java/com/makd/afinity/data/workers/MediaDownloadWorker.kt
+++ b/app/src/main/java/com/makd/afinity/data/workers/MediaDownloadWorker.kt
@@ -31,6 +31,7 @@ import com.makd.afinity.data.repository.DatabaseRepository
 import com.makd.afinity.data.repository.download.JellyfinDownloadRepository
 import com.makd.afinity.data.repository.segments.SegmentsRepository
 import com.makd.afinity.di.DownloadClient
+import com.makd.afinity.util.parseDashlessUuid
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.Dispatchers
@@ -227,7 +228,17 @@ constructor(
                     val outputFile = File(mediaDir, "$sourceId.$extension.download")
                     val finalFile = File(mediaDir, "$sourceId.$extension")
 
-                    val downloadUrl = apiClient.libraryApi.getDownloadUrl(itemId = itemId)
+                    // Each sourceId is actually an itemId corresponding to the specific version that was requested in the download dialog
+                    // Unfortunately, because the SDK expects a UUID, but UUID.fromString doesn't handle strings without dashes, we have
+                    // to do some special handling here to get a UUID to pass to getDownloadUrl
+                    val sourceUuid =
+                        try {
+                            parseDashlessUuid(sourceId)
+                        } catch (e: IllegalArgumentException) {
+                            return@withContext Result.failure(workDataOf("error" to "Invalid source ID"))
+                        }
+
+                    val downloadUrl = apiClient.libraryApi.getDownloadUrl(itemId = sourceUuid)
 
                     val existingFileSize = if (outputFile.exists()) outputFile.length() else 0L
 

--- a/app/src/main/java/com/makd/afinity/util/UuidUtils.kt
+++ b/app/src/main/java/com/makd/afinity/util/UuidUtils.kt
@@ -1,0 +1,17 @@
+package com.makd.afinity.util
+
+import java.util.UUID
+
+fun parseDashlessUuid(noDashesStr: String): UUID {
+    require(noDashesStr.length == 32) { "Invalid UUID string length: must be 32 characters" }
+
+    val hyphenatedStr = buildString(36) {
+        append(noDashesStr)
+        insert(8, "-")
+        insert(13, "-")
+        insert(18, "-")
+        insert(23, "-")
+    }
+
+    return UUID.fromString(hyphenatedStr)
+}


### PR DESCRIPTION
Fixes #152

The selected sourceId is currently being dropped when building the download URL to actually download the item. This PR uses the sourceId to build the download URL instead, so that the correct file is downloaded from the Jellyfin server to match the selected media source.

More details are in the issue linked above.