### PR TITLE
Add support for saving downloads to external storage

### DIFF
--- a/app/src/main/java/com/makd/afinity/data/database/AfinityDatabase.kt
+++ b/app/src/main/java/com/makd/afinity/data/database/AfinityDatabase.kt
@@ -104,7 +104,7 @@ import com.makd.afinity.data.models.user.User
             AbsDownloadEntity::class,
             AudibleRatingEntity::class,
         ],
-    version = 47,
+    version = 48,
     exportSchema = false,
 )
 @TypeConverters(AfinityTypeConverters::class)

--- a/app/src/main/java/com/makd/afinity/data/database/DatabaseMigrations.kt
+++ b/app/src/main/java/com/makd/afinity/data/database/DatabaseMigrations.kt
@@ -1099,6 +1099,15 @@ object DatabaseMigrations {
             }
         }
 
+    val MIGRATION_47_48 =
+        object : Migration(47, 48) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "ALTER TABLE downloads ADD COLUMN storageVolumeId TEXT NOT NULL DEFAULT 'primary'"
+                )
+            }
+        }
+
     val ALL_MIGRATIONS =
         arrayOf(
             MIGRATION_1_2,
@@ -1147,5 +1156,6 @@ object DatabaseMigrations {
             MIGRATION_44_45,
             MIGRATION_45_46,
             MIGRATION_46_47,
+            MIGRATION_47_48,
         )
 }

--- a/app/src/main/java/com/makd/afinity/data/database/dao/ServerDatabaseDao.kt
+++ b/app/src/main/java/com/makd/afinity/data/database/dao/ServerDatabaseDao.kt
@@ -164,6 +164,16 @@ abstract class ServerDatabaseDao {
     @Query("SELECT COALESCE(SUM(totalBytes), 0) FROM downloads WHERE status = 'COMPLETED'")
     abstract suspend fun getTotalBytesAllServers(): Long
 
+    @Query(
+        "SELECT storageVolumeId, COALESCE(SUM(totalBytes), 0) AS totalBytes FROM downloads WHERE serverId = :serverId AND status = 'COMPLETED' GROUP BY storageVolumeId"
+    )
+    abstract suspend fun getTotalBytesPerVolumeForServer(serverId: String): List<VolumeUsage>
+
+    @Query(
+        "SELECT storageVolumeId, COALESCE(SUM(totalBytes), 0) AS totalBytes FROM downloads WHERE status = 'COMPLETED' GROUP BY storageVolumeId"
+    )
+    abstract suspend fun getTotalBytesPerVolume(): List<VolumeUsage>
+
     @Query("UPDATE downloads SET serverId = :serverId, userId = :userId WHERE serverId = ''")
     abstract suspend fun backfillEmptyServerIds(serverId: String, userId: UUID)
 

--- a/app/src/main/java/com/makd/afinity/data/database/dao/VolumeUsage.kt
+++ b/app/src/main/java/com/makd/afinity/data/database/dao/VolumeUsage.kt
@@ -1,0 +1,7 @@
+package com.makd.afinity.data.database.dao
+
+/** Aggregated download storage usage for a single storage volume. */
+data class VolumeUsage(
+    val storageVolumeId: String,
+    val totalBytes: Long,
+)

--- a/app/src/main/java/com/makd/afinity/data/database/entities/DownloadDto.kt
+++ b/app/src/main/java/com/makd/afinity/data/database/entities/DownloadDto.kt
@@ -33,6 +33,7 @@ data class DownloadDto(
     val runtimeTicks: Long?,
     val folderPath: String? = null,
     val seriesId: String? = null,
+    val storageVolumeId: String = "primary",
 )
 
 fun DownloadDto.toDownloadInfo(): DownloadInfo {
@@ -61,5 +62,6 @@ fun DownloadDto.toDownloadInfo(): DownloadInfo {
         releaseYear = releaseYear,
         runtimeTicks = runtimeTicks,
         seriesId = seriesId,
+        storageVolumeId = storageVolumeId,
     )
 }

--- a/app/src/main/java/com/makd/afinity/data/models/download/DownloadInfo.kt
+++ b/app/src/main/java/com/makd/afinity/data/models/download/DownloadInfo.kt
@@ -27,4 +27,5 @@ data class DownloadInfo(
     val releaseYear: String? = null,
     val runtimeTicks: Long? = null,
     val seriesId: String? = null,
+    val storageVolumeId: String = "primary",
 )

--- a/app/src/main/java/com/makd/afinity/data/repository/DatabaseRepository.kt
+++ b/app/src/main/java/com/makd/afinity/data/repository/DatabaseRepository.kt
@@ -237,6 +237,10 @@ interface DatabaseRepository {
 
     suspend fun getTotalBytesAllServers(): Long
 
+    suspend fun getTotalBytesPerVolumeForServer(serverId: String): Map<String, Long>
+
+    suspend fun getTotalBytesPerVolumeAllServers(): Map<String, Long>
+
     suspend fun backfillEmptyServerIds(serverId: String, userId: UUID)
 
     suspend fun deleteDownload(downloadId: UUID)

--- a/app/src/main/java/com/makd/afinity/data/repository/PreferencesRepository.kt
+++ b/app/src/main/java/com/makd/afinity/data/repository/PreferencesRepository.kt
@@ -164,6 +164,12 @@ interface PreferencesRepository {
 
     suspend fun getMaxDownloads(): Int
 
+    suspend fun setDownloadStorageVolumeId(volumeId: String)
+
+    suspend fun getDownloadStorageVolumeId(): String
+
+    fun getDownloadStorageVolumeIdFlow(): Flow<String>
+
     suspend fun setSyncEnabled(enabled: Boolean)
 
     suspend fun getSyncEnabled(): Boolean

--- a/app/src/main/java/com/makd/afinity/data/repository/download/DownloadRepository.kt
+++ b/app/src/main/java/com/makd/afinity/data/repository/download/DownloadRepository.kt
@@ -21,6 +21,13 @@ interface DownloadRepository {
 
     suspend fun deleteDownload(downloadId: UUID): Result<Unit>
 
+    /**
+     * Removes a download's database records (and local sources) **without** touching files on disk.
+     * Used to clear an entry whose storage volume is currently unavailable (e.g. SD card removed),
+     * leaving any on-volume files to be reclaimed when the volume returns.
+     */
+    suspend fun removeDownloadRecord(downloadId: UUID): Result<Unit>
+
     suspend fun getDownload(downloadId: UUID): DownloadInfo?
 
     suspend fun getDownloadByItemId(itemId: UUID): DownloadInfo?
@@ -51,7 +58,7 @@ interface DownloadRepository {
         volumeId: String? = null,
     ): Result<Int>
 
-    suspend fun startSeriesDownload(showId: UUID): Result<Int>
+    suspend fun startSeriesDownload(showId: UUID, volumeId: String? = null): Result<Int>
 
     suspend fun cancelAllSeriesDownloads(showId: UUID): Result<Unit>
 

--- a/app/src/main/java/com/makd/afinity/data/repository/download/DownloadRepository.kt
+++ b/app/src/main/java/com/makd/afinity/data/repository/download/DownloadRepository.kt
@@ -37,6 +37,10 @@ interface DownloadRepository {
 
     suspend fun getTotalStorageUsedAllServers(): Long
 
+    suspend fun getStorageUsedPerVolume(): Map<String, Long>
+
+    suspend fun getStorageUsedPerVolumeAllServers(): Map<String, Long>
+
     suspend fun startSeasonDownload(seasonId: UUID, seriesId: UUID? = null): Result<Int>
 
     suspend fun startSeriesDownload(showId: UUID): Result<Int>

--- a/app/src/main/java/com/makd/afinity/data/repository/download/DownloadRepository.kt
+++ b/app/src/main/java/com/makd/afinity/data/repository/download/DownloadRepository.kt
@@ -7,7 +7,11 @@ import kotlinx.coroutines.flow.Flow
 
 interface DownloadRepository {
 
-    suspend fun startDownload(itemId: UUID, sourceId: String): Result<UUID>
+    suspend fun startDownload(
+        itemId: UUID,
+        sourceId: String,
+        volumeId: String? = null,
+    ): Result<UUID>
 
     suspend fun pauseDownload(downloadId: UUID): Result<Unit>
 
@@ -41,7 +45,11 @@ interface DownloadRepository {
 
     suspend fun getStorageUsedPerVolumeAllServers(): Map<String, Long>
 
-    suspend fun startSeasonDownload(seasonId: UUID, seriesId: UUID? = null): Result<Int>
+    suspend fun startSeasonDownload(
+        seasonId: UUID,
+        seriesId: UUID? = null,
+        volumeId: String? = null,
+    ): Result<Int>
 
     suspend fun startSeriesDownload(showId: UUID): Result<Int>
 

--- a/app/src/main/java/com/makd/afinity/data/repository/download/JellyfinDownloadRepository.kt
+++ b/app/src/main/java/com/makd/afinity/data/repository/download/JellyfinDownloadRepository.kt
@@ -482,6 +482,27 @@ constructor(
             }
         }
 
+    override suspend fun getStorageUsedPerVolume(): Map<String, Long> =
+        withContext(Dispatchers.IO) {
+            return@withContext try {
+                val session = sessionManager.currentSession.value ?: return@withContext emptyMap()
+                databaseRepository.getTotalBytesPerVolumeForServer(session.serverId)
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to calculate per-volume storage used")
+                emptyMap()
+            }
+        }
+
+    override suspend fun getStorageUsedPerVolumeAllServers(): Map<String, Long> =
+        withContext(Dispatchers.IO) {
+            return@withContext try {
+                databaseRepository.getTotalBytesPerVolumeAllServers()
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to calculate per-volume storage used")
+                emptyMap()
+            }
+        }
+
     fun getDownloadDirectory(): File = downloadDir
 
     suspend fun getItemDownloadDirectory(itemId: UUID): File {

--- a/app/src/main/java/com/makd/afinity/data/repository/download/JellyfinDownloadRepository.kt
+++ b/app/src/main/java/com/makd/afinity/data/repository/download/JellyfinDownloadRepository.kt
@@ -20,6 +20,7 @@ import com.makd.afinity.data.models.media.AfinitySourceType
 import com.makd.afinity.data.repository.DatabaseRepository
 import com.makd.afinity.data.repository.PreferencesRepository
 import com.makd.afinity.data.repository.media.MediaRepository
+import com.makd.afinity.data.storage.StorageLocationProvider
 import com.makd.afinity.data.workers.ImageDownloadWorker
 import com.makd.afinity.data.workers.MediaDownloadWorker
 import com.makd.afinity.data.workers.SubtitleDownloadWorker
@@ -50,6 +51,7 @@ constructor(
     private val mediaRepository: MediaRepository,
     private val databaseRepository: DatabaseRepository,
     private val preferencesRepository: PreferencesRepository,
+    private val storageLocationProvider: StorageLocationProvider,
     private val workManager: WorkManager,
 ) : DownloadRepository {
 
@@ -62,18 +64,30 @@ constructor(
         const val MAX_CONCURRENT_DOWNLOADS = 2
     }
 
-    private val downloadDir: File
-        get() {
-            val dir = File(context.getExternalFilesDir(null), "AFinity/Downloads")
-            if (!dir.exists() && !dir.mkdirs()) {
-                Timber.e("Failed to create base download directory at ${dir.absolutePath}")
-            }
-            return dir
+    /**
+     * Resolves the `AFinity/Downloads` base directory for the given volume. Falls back to the
+     * primary volume when the requested volume is no longer mounted (e.g. SD card removed).
+     */
+    private fun baseDir(volumeId: String): File {
+        val dir =
+            storageLocationProvider.resolveBaseDir(volumeId)
+                ?: storageLocationProvider.primaryBaseDir()
+        if (!dir.exists() && !dir.mkdirs()) {
+            Timber.e("Failed to create base download directory at ${dir.absolutePath}")
         }
+        return dir
+    }
 
-    override suspend fun startDownload(itemId: UUID, sourceId: String): Result<UUID> =
+    override suspend fun startDownload(
+        itemId: UUID,
+        sourceId: String,
+        volumeId: String?,
+    ): Result<UUID> =
         withContext(Dispatchers.IO) {
             return@withContext try {
+                val resolvedVolumeId =
+                    volumeId ?: preferencesRepository.getDownloadStorageVolumeId()
+
                 val currentSession =
                     sessionManager.currentSession.value
                         ?: return@withContext Result.failure(Exception("No active session"))
@@ -196,6 +210,7 @@ constructor(
                         runtimeTicks = runtimeTicks,
                         folderPath = folderPath,
                         seriesId = (item as? AfinityEpisode)?.seriesId?.toString(),
+                        storageVolumeId = resolvedVolumeId,
                     )
 
                 databaseRepository.insertDownload(download)
@@ -364,7 +379,7 @@ constructor(
                         ?: return@withContext Result.failure(Exception("Download not found"))
 
                 val targetPath = download.folderPath ?: download.itemId.toString()
-                val itemFolder = File(downloadDir, targetPath)
+                val itemFolder = File(baseDir(download.storageVolumeId), targetPath)
 
                 if (itemFolder.exists()) {
                     itemFolder.deleteRecursively()
@@ -503,34 +518,45 @@ constructor(
             }
         }
 
-    fun getDownloadDirectory(): File = downloadDir
+    fun getDownloadDirectory(): File = baseDir(StorageLocationProvider.PRIMARY_VOLUME_ID)
 
     suspend fun getItemDownloadDirectory(itemId: UUID): File {
-        val folderPath = databaseRepository.getDownloadByItemId(itemId)?.folderPath
-        val dir = File(downloadDir, folderPath ?: itemId.toString())
+        val download = databaseRepository.getDownloadByItemId(itemId)
+        val folderPath = download?.folderPath
+        val volumeId = download?.storageVolumeId ?: StorageLocationProvider.PRIMARY_VOLUME_ID
+        val dir = File(baseDir(volumeId), folderPath ?: itemId.toString())
         if (!dir.exists() && !dir.mkdirs()) Timber.w("Failed to create item directory")
         return dir
     }
 
     fun getShowDirectory(serverId: String, showId: UUID): File {
-        val dir = File(downloadDir, "$serverId/shows/$showId")
+        val dir =
+            File(baseDir(StorageLocationProvider.PRIMARY_VOLUME_ID), "$serverId/shows/$showId")
         if (!dir.exists() && !dir.mkdirs()) Timber.w("Failed to create show directory")
         return dir
     }
 
     fun getSeasonDirectory(serverId: String, showId: UUID, seasonNumber: Int): File {
-        val dir = File(downloadDir, "$serverId/shows/$showId/seasons/$seasonNumber")
+        val dir =
+            File(
+                baseDir(StorageLocationProvider.PRIMARY_VOLUME_ID),
+                "$serverId/shows/$showId/seasons/$seasonNumber",
+            )
         if (!dir.exists() && !dir.mkdirs()) Timber.w("Failed to create season directory")
         return dir
     }
 
-    override suspend fun startSeasonDownload(seasonId: UUID, seriesId: UUID?): Result<Int> =
+    override suspend fun startSeasonDownload(
+        seasonId: UUID,
+        seriesId: UUID?,
+        volumeId: String?,
+    ): Result<Int> =
         withContext(Dispatchers.IO) {
             return@withContext try {
                 val episodes = mediaRepository.getEpisodes(seasonId, seriesId)
                 var started = 0
                 for (episode in episodes) {
-                    startDownload(episode.id, "")
+                    startDownload(episode.id, "", volumeId)
                         .onSuccess { started++ }
                         .onFailure {
                             Timber.w(it, "Skipping episode ${episode.name}: ${it.message}")

--- a/app/src/main/java/com/makd/afinity/data/repository/download/JellyfinDownloadRepository.kt
+++ b/app/src/main/java/com/makd/afinity/data/repository/download/JellyfinDownloadRepository.kt
@@ -21,6 +21,7 @@ import com.makd.afinity.data.repository.DatabaseRepository
 import com.makd.afinity.data.repository.PreferencesRepository
 import com.makd.afinity.data.repository.media.MediaRepository
 import com.makd.afinity.data.storage.StorageLocationProvider
+import com.makd.afinity.data.storage.VolumeUnavailableException
 import com.makd.afinity.data.workers.ImageDownloadWorker
 import com.makd.afinity.data.workers.MediaDownloadWorker
 import com.makd.afinity.data.workers.SubtitleDownloadWorker
@@ -65,13 +66,23 @@ constructor(
     }
 
     /**
-     * Resolves the `AFinity/Downloads` base directory for the given volume. Falls back to the
-     * primary volume when the requested volume is no longer mounted (e.g. SD card removed).
+     * Resolves the `AFinity/Downloads` base directory for the given volume. Throws
+     * [VolumeUnavailableException] when a non-primary volume is no longer mounted (e.g. the SD card
+     * was removed) rather than silently retargeting to primary — silently falling back would let
+     * deletes/cleanup no-op on the absent volume's files while still mutating state, orphaning the
+     * media. The primary volume is always resolvable.
      */
     private fun baseDir(volumeId: String): File {
         val dir =
-            storageLocationProvider.resolveBaseDir(volumeId)
-                ?: storageLocationProvider.primaryBaseDir()
+            if (volumeId == StorageLocationProvider.PRIMARY_VOLUME_ID) {
+                storageLocationProvider.primaryBaseDir()
+            } else {
+                storageLocationProvider.resolveBaseDir(volumeId)
+                    ?: throw VolumeUnavailableException(
+                        volumeId,
+                        storageLocationProvider.displayNameFor(volumeId),
+                    )
+            }
         if (!dir.exists() && !dir.mkdirs()) {
             Timber.e("Failed to create base download directory at ${dir.absolutePath}")
         }
@@ -85,8 +96,24 @@ constructor(
     ): Result<UUID> =
         withContext(Dispatchers.IO) {
             return@withContext try {
-                val resolvedVolumeId =
+                // An explicit volume choice that is no longer mounted is an error — fail loudly
+                // rather than silently retargeting the user's deliberate selection.
+                if (volumeId != null && !storageLocationProvider.isVolumeAvailable(volumeId)) {
+                    return@withContext Result.failure(
+                        VolumeUnavailableException(
+                            volumeId,
+                            storageLocationProvider.displayNameFor(volumeId),
+                        )
+                    )
+                }
+
+                // Fall back to the primary volume when the global default is unavailable so a
+                // tap-to-download never fails just because an SD card was removed.
+                val requestedVolumeId =
                     volumeId ?: preferencesRepository.getDownloadStorageVolumeId()
+                val resolvedVolumeId =
+                    if (storageLocationProvider.isVolumeAvailable(requestedVolumeId)) requestedVolumeId
+                    else StorageLocationProvider.PRIMARY_VOLUME_ID
 
                 val currentSession =
                     sessionManager.currentSession.value
@@ -378,8 +405,13 @@ constructor(
                     databaseRepository.getDownload(downloadId)
                         ?: return@withContext Result.failure(Exception("Download not found"))
 
+                // baseDir throws VolumeUnavailableException when the item's volume is gone, so a
+                // delete can never no-op on absent files while dropping the DB rows. The UI catches
+                // that and offers "remove from list" instead.
+                val baseDir = baseDir(download.storageVolumeId)
+
                 val targetPath = download.folderPath ?: download.itemId.toString()
-                val itemFolder = File(baseDir(download.storageVolumeId), targetPath)
+                val itemFolder = File(baseDir, targetPath)
 
                 if (itemFolder.exists()) {
                     itemFolder.deleteRecursively()
@@ -395,6 +427,27 @@ constructor(
                 Result.success(Unit)
             } catch (e: Exception) {
                 Timber.e(e, "Failed to delete download")
+                Result.failure(e)
+            }
+        }
+
+    override suspend fun removeDownloadRecord(downloadId: UUID): Result<Unit> =
+        withContext(Dispatchers.IO) {
+            return@withContext try {
+                val download =
+                    databaseRepository.getDownload(downloadId)
+                        ?: return@withContext Result.failure(Exception("Download not found"))
+
+                val sources = databaseRepository.getSources(download.itemId)
+                sources
+                    .filter { it.type == AfinitySourceType.LOCAL }
+                    .forEach { databaseRepository.deleteSource(it.id) }
+
+                databaseRepository.deleteDownload(downloadId)
+
+                Result.success(Unit)
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to remove download record")
                 Result.failure(e)
             }
         }
@@ -570,13 +623,13 @@ constructor(
             }
         }
 
-    override suspend fun startSeriesDownload(showId: UUID): Result<Int> =
+    override suspend fun startSeriesDownload(showId: UUID, volumeId: String?): Result<Int> =
         withContext(Dispatchers.IO) {
             return@withContext try {
                 val seasons = mediaRepository.getSeasons(showId)
                 var totalStarted = 0
                 for (season in seasons) {
-                    startSeasonDownload(season.id, showId)
+                    startSeasonDownload(season.id, showId, volumeId)
                         .onSuccess { count -> totalStarted += count }
                         .onFailure { Timber.w(it, "Skipping season ${season.name}: ${it.message}") }
                 }

--- a/app/src/main/java/com/makd/afinity/data/repository/impl/DatabaseRepositoryImpl.kt
+++ b/app/src/main/java/com/makd/afinity/data/repository/impl/DatabaseRepositoryImpl.kt
@@ -781,6 +781,18 @@ constructor(
         return serverDatabaseDao.getTotalBytesAllServers()
     }
 
+    override suspend fun getTotalBytesPerVolumeForServer(serverId: String): Map<String, Long> {
+        return serverDatabaseDao.getTotalBytesPerVolumeForServer(serverId).associate {
+            it.storageVolumeId to it.totalBytes
+        }
+    }
+
+    override suspend fun getTotalBytesPerVolumeAllServers(): Map<String, Long> {
+        return serverDatabaseDao.getTotalBytesPerVolume().associate {
+            it.storageVolumeId to it.totalBytes
+        }
+    }
+
     override suspend fun backfillEmptyServerIds(serverId: String, userId: UUID) {
         serverDatabaseDao.backfillEmptyServerIds(serverId, userId)
     }

--- a/app/src/main/java/com/makd/afinity/data/repository/impl/PreferencesRepositoryImpl.kt
+++ b/app/src/main/java/com/makd/afinity/data/repository/impl/PreferencesRepositoryImpl.kt
@@ -67,6 +67,7 @@ constructor(@param:AppPreferences private val dataStore: DataStore<Preferences>)
         val DOWNLOAD_WIFI_ONLY = booleanPreferencesKey("download_wifi_only")
         val DOWNLOAD_QUALITY = stringPreferencesKey("download_quality")
         val MAX_DOWNLOADS = intPreferencesKey("max_downloads")
+        val DOWNLOAD_STORAGE_VOLUME_ID = stringPreferencesKey("download_storage_volume_id")
 
         val SYNC_ENABLED = booleanPreferencesKey("sync_enabled")
         val SYNC_INTERVAL = intPreferencesKey("sync_interval")
@@ -340,6 +341,17 @@ constructor(@param:AppPreferences private val dataStore: DataStore<Preferences>)
     override suspend fun getMaxDownloads(): Int {
         return dataStore.data.first()[Keys.MAX_DOWNLOADS] ?: 3
     }
+
+    override suspend fun setDownloadStorageVolumeId(volumeId: String) {
+        dataStore.edit { preferences -> preferences[Keys.DOWNLOAD_STORAGE_VOLUME_ID] = volumeId }
+    }
+
+    override suspend fun getDownloadStorageVolumeId(): String {
+        return dataStore.data.first()[Keys.DOWNLOAD_STORAGE_VOLUME_ID] ?: "primary"
+    }
+
+    override fun getDownloadStorageVolumeIdFlow(): Flow<String> =
+        dataStore.data.map { it[Keys.DOWNLOAD_STORAGE_VOLUME_ID] ?: "primary" }
 
     override suspend fun setSyncEnabled(enabled: Boolean) {
         dataStore.edit { preferences -> preferences[Keys.SYNC_ENABLED] = enabled }

--- a/app/src/main/java/com/makd/afinity/data/repository/media/JellyfinMediaRepository.kt
+++ b/app/src/main/java/com/makd/afinity/data/repository/media/JellyfinMediaRepository.kt
@@ -36,6 +36,7 @@ import com.makd.afinity.data.paging.JellyfinItemsPagingSource
 import com.makd.afinity.data.repository.DatabaseRepository
 import com.makd.afinity.data.repository.FieldSets
 import com.makd.afinity.data.repository.SecurePreferencesRepository
+import com.makd.afinity.data.storage.StorageLocationProvider
 import com.makd.afinity.ui.library.FilterType
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
@@ -87,6 +88,7 @@ constructor(
     private val omdbApiService: OmdbApiService,
     private val securePreferencesRepository: SecurePreferencesRepository,
     private val databaseRepository: DatabaseRepository,
+    private val storageLocationProvider: StorageLocationProvider,
 ) : MediaRepository {
     override suspend fun refreshItemUserData(
         itemId: UUID,
@@ -1433,30 +1435,29 @@ constructor(
     override suspend fun getTrickplayData(itemId: UUID, width: Int, index: Int): ByteArray? =
         withContext(Dispatchers.IO) {
             try {
-                val externalFilesDir = context.getExternalFilesDir(null)
                 Timber.d(
                     "Attempting to load trickplay tile: itemId=$itemId, width=$width, index=$index"
                 )
 
-                if (externalFilesDir != null) {
-                    val downloadDir = File(externalFilesDir, "AFinity/Downloads")
-                    val folderPath = databaseRepository.getDownloadByItemId(itemId)?.folderPath
-                    val itemDir = File(downloadDir, folderPath ?: itemId.toString())
-                    val trickplayFile = File(itemDir, "trickplay/$width/$index.jpg")
+                val download = databaseRepository.getDownloadByItemId(itemId)
+                val volumeId =
+                    download?.storageVolumeId ?: StorageLocationProvider.PRIMARY_VOLUME_ID
+                val baseDir =
+                    storageLocationProvider.resolveBaseDir(volumeId)
+                        ?: storageLocationProvider.primaryBaseDir()
+                val itemDir = File(baseDir, download?.folderPath ?: itemId.toString())
+                val trickplayFile = File(itemDir, "trickplay/$width/$index.jpg")
 
-                    Timber.d("Looking for trickplay file: ${trickplayFile.absolutePath}")
-                    Timber.d("File exists: ${trickplayFile.exists()}")
+                Timber.d("Looking for trickplay file: ${trickplayFile.absolutePath}")
+                Timber.d("File exists: ${trickplayFile.exists()}")
 
-                    if (trickplayFile.exists()) {
-                        Timber.i(
-                            "Loading trickplay tile from local storage: $width/$index.jpg (${trickplayFile.length()} bytes)"
-                        )
-                        return@withContext trickplayFile.readBytes()
-                    } else {
-                        Timber.d("Trickplay file not found locally, trying API")
-                    }
+                if (trickplayFile.exists()) {
+                    Timber.i(
+                        "Loading trickplay tile from local storage: $width/$index.jpg (${trickplayFile.length()} bytes)"
+                    )
+                    return@withContext trickplayFile.readBytes()
                 } else {
-                    Timber.w("External files directory is null")
+                    Timber.d("Trickplay file not found locally, trying API")
                 }
             } catch (e: Exception) {
                 Timber.w(e, "Failed to load trickplay from local storage, falling back to API")

--- a/app/src/main/java/com/makd/afinity/data/storage/StorageLocationProvider.kt
+++ b/app/src/main/java/com/makd/afinity/data/storage/StorageLocationProvider.kt
@@ -1,0 +1,82 @@
+package com.makd.afinity.data.storage
+
+import android.content.Context
+import android.os.storage.StorageManager
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+import timber.log.Timber
+
+/**
+ * Resolves the available storage volumes (internal + removable SD cards / USB-OTG) that the app can
+ * write downloads to, keyed by a stable volume id.
+ *
+ * The primary volume is always keyed as [PRIMARY_VOLUME_ID]; removable volumes are keyed by their
+ * [android.os.storage.StorageVolume.getUuid] (the FAT serial, e.g. `ABCD-1234`), which is stable
+ * across reboots and only changes on reformat.
+ */
+@Singleton
+class StorageLocationProvider
+@Inject
+constructor(@param:ApplicationContext private val context: Context) {
+
+    companion object {
+        const val PRIMARY_VOLUME_ID = "primary"
+        private const val DOWNLOADS_SUBPATH = "AFinity/Downloads"
+    }
+
+    private val storageManager: StorageManager by lazy {
+        context.getSystemService(Context.STORAGE_SERVICE) as StorageManager
+    }
+
+    /**
+     * Returns the currently mounted volumes the app can use, each with its `AFinity/Downloads`
+     * base directory. Volumes that are unmounted (a `null` entry in [Context.getExternalFilesDirs])
+     * are skipped. The primary volume is always included and always keyed [PRIMARY_VOLUME_ID].
+     */
+    fun listVolumes(): List<StorageVolumeInfo> {
+        val dirs = context.getExternalFilesDirs(null)
+        val result = mutableListOf<StorageVolumeInfo>()
+
+        for (dir in dirs) {
+            if (dir == null) continue
+            try {
+                val volume = storageManager.getStorageVolume(dir) ?: continue
+                val isPrimary = volume.isPrimary
+                val id = if (isPrimary) PRIMARY_VOLUME_ID else volume.uuid ?: continue
+                val displayName =
+                    volume.getDescription(context)
+                        ?: if (isPrimary) "Internal storage" else "SD card"
+                result.add(
+                    StorageVolumeInfo(
+                        id = id,
+                        displayName = displayName,
+                        isRemovable = volume.isRemovable,
+                        isPrimary = isPrimary,
+                        baseDir = File(dir, DOWNLOADS_SUBPATH),
+                    )
+                )
+            } catch (e: Exception) {
+                Timber.w(e, "Failed to resolve storage volume for dir: ${dir.absolutePath}")
+            }
+        }
+
+        return result
+    }
+
+    /**
+     * Resolves the `AFinity/Downloads` base directory for the given volume id, or `null` when that
+     * volume is not currently mounted (e.g. the SD card was removed).
+     */
+    fun resolveBaseDir(volumeId: String): File? =
+        listVolumes().firstOrNull { it.id == volumeId }?.baseDir
+
+    /**
+     * The primary (internal) volume's base directory. Always available, used as the fallback when a
+     * stored volume id can no longer be resolved.
+     */
+    fun primaryBaseDir(): File =
+        resolveBaseDir(PRIMARY_VOLUME_ID)
+            ?: File(context.getExternalFilesDir(null), DOWNLOADS_SUBPATH)
+}

--- a/app/src/main/java/com/makd/afinity/data/storage/StorageLocationProvider.kt
+++ b/app/src/main/java/com/makd/afinity/data/storage/StorageLocationProvider.kt
@@ -73,6 +73,20 @@ constructor(@param:ApplicationContext private val context: Context) {
         listVolumes().firstOrNull { it.id == volumeId }?.baseDir
 
     /**
+     * Whether the given volume is currently mounted and writable. The primary volume is always
+     * considered available.
+     */
+    fun isVolumeAvailable(volumeId: String): Boolean =
+        volumeId == PRIMARY_VOLUME_ID || resolveBaseDir(volumeId) != null
+
+    /** Stable ids of all currently mounted volumes. */
+    fun mountedVolumeIds(): Set<String> = listVolumes().map { it.id }.toSet()
+
+    /** User-visible name for a volume id, or `null` when it is not currently mounted. */
+    fun displayNameFor(volumeId: String): String? =
+        listVolumes().firstOrNull { it.id == volumeId }?.displayName
+
+    /**
      * The primary (internal) volume's base directory. Always available, used as the fallback when a
      * stored volume id can no longer be resolved.
      */

--- a/app/src/main/java/com/makd/afinity/data/storage/StorageVolumeInfo.kt
+++ b/app/src/main/java/com/makd/afinity/data/storage/StorageVolumeInfo.kt
@@ -1,0 +1,21 @@
+package com.makd.afinity.data.storage
+
+import java.io.File
+
+/**
+ * Describes a storage volume the app can download to.
+ *
+ * @property id Stable key persisted in the DB and preferences.
+ *   [StorageLocationProvider.PRIMARY_VOLUME_ID] for the primary volume, otherwise the volume UUID.
+ * @property displayName User-visible name (e.g. "Internal storage", "SD card").
+ * @property isRemovable Whether the volume is removable (SD card / USB-OTG).
+ * @property isPrimary Whether this is the primary (internal) volume.
+ * @property baseDir The `AFinity/Downloads` directory on this volume.
+ */
+data class StorageVolumeInfo(
+    val id: String,
+    val displayName: String,
+    val isRemovable: Boolean,
+    val isPrimary: Boolean,
+    val baseDir: File,
+)

--- a/app/src/main/java/com/makd/afinity/data/storage/VolumeUnavailableException.kt
+++ b/app/src/main/java/com/makd/afinity/data/storage/VolumeUnavailableException.kt
@@ -1,0 +1,11 @@
+package com.makd.afinity.data.storage
+
+/**
+ * Thrown when an operation targets a storage volume that is not currently mounted (e.g. an SD card
+ * that has been removed). Carries the user-visible volume name when known so the UI can surface a
+ * helpful message.
+ */
+class VolumeUnavailableException(
+    val volumeId: String,
+    val volumeName: String?,
+) : Exception("Storage volume '${volumeName ?: volumeId}' is not available")

--- a/app/src/main/java/com/makd/afinity/data/workers/ImageDownloadWorker.kt
+++ b/app/src/main/java/com/makd/afinity/data/workers/ImageDownloadWorker.kt
@@ -99,7 +99,6 @@ constructor(
                     "Loaded item from database: ${item.name}, has images: ${item.images.primary != null}"
                 )
 
-                applicationContext.getExternalFilesDir(null)
                 val itemDir = downloadRepository.getItemDownloadDirectory(itemId)
                 val imagesDir = File(itemDir, "images")
 

--- a/app/src/main/java/com/makd/afinity/data/workers/MediaDownloadWorker.kt
+++ b/app/src/main/java/com/makd/afinity/data/workers/MediaDownloadWorker.kt
@@ -208,8 +208,6 @@ constructor(
                                 workDataOf("error" to "Source not found")
                             )
 
-                    applicationContext.getExternalFilesDir(null)
-
                     val itemDir = downloadRepository.getItemDownloadDirectory(itemId)
                     val mediaDir = File(itemDir, "media")
 

--- a/app/src/main/java/com/makd/afinity/data/workers/SubtitleDownloadWorker.kt
+++ b/app/src/main/java/com/makd/afinity/data/workers/SubtitleDownloadWorker.kt
@@ -143,7 +143,6 @@ constructor(
                     return@withContext Result.success()
                 }
 
-                applicationContext.getExternalFilesDir(null)
                 val itemDir = downloadRepository.getItemDownloadDirectory(itemId)
                 val subtitlesDir = File(itemDir, "subtitles")
 

--- a/app/src/main/java/com/makd/afinity/data/workers/TrickplayDownloadWorker.kt
+++ b/app/src/main/java/com/makd/afinity/data/workers/TrickplayDownloadWorker.kt
@@ -136,7 +136,6 @@ constructor(
                     return@withContext Result.success()
                 }
 
-                applicationContext.getExternalFilesDir(null)
                 val itemDir = downloadRepository.getItemDownloadDirectory(itemId)
                 val trickplayDir = File(itemDir, "trickplay")
 

--- a/app/src/main/java/com/makd/afinity/ui/components/EpisodeOverlayHandler.kt
+++ b/app/src/main/java/com/makd/afinity/ui/components/EpisodeOverlayHandler.kt
@@ -7,13 +7,18 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.media3.common.util.UnstableApi
 import com.makd.afinity.data.models.download.DownloadInfo
 import com.makd.afinity.data.models.media.AfinityEpisode
+import com.makd.afinity.data.models.media.AfinitySourceType
+import com.makd.afinity.data.storage.StorageVolumeInfo
 import com.makd.afinity.ui.item.components.EpisodeDetailOverlay
+import com.makd.afinity.ui.item.components.QualitySelectionDialog
 import com.makd.afinity.ui.player.PlayerLauncher
+import com.makd.afinity.util.rememberItemDownloadDelegate
 import kotlinx.coroutines.delay
 
 @Composable
@@ -26,14 +31,16 @@ fun EpisodeOverlayHandler(
     onToggleFavorite: (AfinityEpisode) -> Unit,
     onToggleWatchlist: (AfinityEpisode) -> Unit,
     onToggleWatched: (AfinityEpisode) -> Unit,
-    onDownloadClick: () -> Unit,
-    onPauseDownload: () -> Unit,
-    onResumeDownload: () -> Unit,
-    onCancelDownload: () -> Unit,
     onNavigateToSeries: (seriesId: String) -> Unit,
 ) {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val downloadDelegate = rememberItemDownloadDelegate()
     var pendingNavigationSeriesId by remember { mutableStateOf<String?>(null) }
+
+    var showQualityDialog by remember { mutableStateOf(false) }
+    var volumes by remember { mutableStateOf<List<StorageVolumeInfo>>(emptyList()) }
+    var selectedVolumeId by remember { mutableStateOf<String?>(null) }
 
     selectedEpisode?.let { episode ->
         EpisodeDetailOverlay(
@@ -59,15 +66,54 @@ fun EpisodeOverlayHandler(
             onToggleFavorite = { onToggleFavorite(episode) },
             onToggleWatchlist = { onToggleWatchlist(episode) },
             onToggleWatched = { onToggleWatched(episode) },
-            onDownloadClick = onDownloadClick,
-            onPauseDownload = onPauseDownload,
-            onResumeDownload = onResumeDownload,
-            onCancelDownload = onCancelDownload,
+            onDownloadClick = {
+                downloadDelegate.onDownloadClick(scope, episode) {
+                    volumes = emptyList()
+                    selectedVolumeId = null
+                    showQualityDialog = true
+                }
+            },
+            onPauseDownload = { downloadDelegate.pauseDownload(scope, downloadInfo) },
+            onResumeDownload = { downloadDelegate.resumeDownload(scope, downloadInfo) },
+            onCancelDownload = { downloadDelegate.cancelDownload(scope, downloadInfo) },
+            onDownloadLongClick = {
+                downloadDelegate.onDownloadLongClick(scope, episode) {
+                    loadedVolumes,
+                    defaultVolumeId ->
+                    volumes = loadedVolumes
+                    selectedVolumeId = defaultVolumeId
+                    showQualityDialog = true
+                }
+            },
             onGoToSeries = {
                 onClearSelection()
                 pendingNavigationSeriesId = episode.seriesId?.toString()
             },
         )
+    }
+
+    if (showQualityDialog) {
+        val remoteSources =
+            selectedEpisode?.sources?.filter { it.type == AfinitySourceType.REMOTE } ?: emptyList()
+        if (remoteSources.isNotEmpty()) {
+            QualitySelectionDialog(
+                sources = remoteSources,
+                onSourceSelected = {},
+                onDismiss = { showQualityDialog = false },
+                volumes = volumes,
+                selectedVolumeId = selectedVolumeId,
+                onVolumeSelected = { selectedVolumeId = it },
+                onConfirm = { source, volumeId ->
+                    downloadDelegate.onQualitySelected(
+                        scope = scope,
+                        item = selectedEpisode,
+                        sourceId = source.id,
+                        volumeId = volumeId,
+                        hideQualityDialog = { showQualityDialog = false },
+                    )
+                },
+            )
+        }
     }
 
     LaunchedEffect(selectedEpisode, pendingNavigationSeriesId) {

--- a/app/src/main/java/com/makd/afinity/ui/components/MediaItemCard.kt
+++ b/app/src/main/java/com/makd/afinity/ui/components/MediaItemCard.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
@@ -53,6 +54,7 @@ fun MediaItemCard(
     onClick: () -> Unit,
     cardWidth: Dp,
     modifier: Modifier = Modifier,
+    isUnavailable: Boolean = false,
 ) {
     val density = LocalDensity.current
     val fontScale = density.fontScale
@@ -73,8 +75,30 @@ fun MediaItemCard(
                     targetWidth = cardWidth,
                     targetHeight = cardWidth * 3f / 2f,
                     contentScale = ContentScale.Crop,
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier.fillMaxSize().alpha(if (isUnavailable) 0.4f else 1f),
                 )
+
+                if (isUnavailable) {
+                    Box(
+                        modifier =
+                            Modifier.align(Alignment.TopStart)
+                                .padding(8.dp)
+                                .size(24.dp)
+                                .background(
+                                    MaterialTheme.colorScheme.errorContainer,
+                                    CircleShape,
+                                ),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_cloud_off),
+                            contentDescription =
+                                stringResource(R.string.download_unavailable_indicator),
+                            tint = MaterialTheme.colorScheme.onErrorContainer,
+                            modifier = Modifier.size(16.dp),
+                        )
+                    }
+                }
 
                 val visuallyPlayed = item.played
 

--- a/app/src/main/java/com/makd/afinity/ui/downloads/DownloadsViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/downloads/DownloadsViewModel.kt
@@ -1,16 +1,22 @@
 package com.makd.afinity.ui.downloads
 
+import android.content.Context
 import android.os.Environment
 import android.os.StatFs
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.makd.afinity.R
 import com.makd.afinity.data.models.audiobookshelf.AbsDownloadInfo
 import com.makd.afinity.data.models.download.DownloadInfo
 import com.makd.afinity.data.models.download.DownloadStatus
 import com.makd.afinity.data.repository.PreferencesRepository
 import com.makd.afinity.data.repository.audiobookshelf.AbsDownloadRepository
 import com.makd.afinity.data.repository.download.DownloadRepository
+import com.makd.afinity.data.storage.StorageLocationProvider
+import com.makd.afinity.data.storage.StorageVolumeInfo
+import com.makd.afinity.data.storage.VolumeUnavailableException
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -26,9 +32,11 @@ import javax.inject.Inject
 class DownloadsViewModel
 @Inject
 constructor(
+    @param:ApplicationContext private val context: Context,
     private val downloadRepository: DownloadRepository,
     private val absDownloadRepository: AbsDownloadRepository,
     private val preferencesRepository: PreferencesRepository,
+    private val storageLocationProvider: StorageLocationProvider,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(DownloadsUiState())
@@ -38,6 +46,34 @@ constructor(
         observeDownloads()
         loadStorageInfo()
         loadDownloadPreferences()
+        loadStorageVolumes()
+    }
+
+    private fun loadStorageVolumes() {
+        viewModelScope.launch {
+            try {
+                val volumes = storageLocationProvider.listVolumes()
+                val defaultVolumeId = preferencesRepository.getDownloadStorageVolumeId()
+                _uiState.value =
+                    _uiState.value.copy(
+                        availableVolumes = volumes,
+                        defaultStorageVolumeId = defaultVolumeId,
+                    )
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to load storage volumes")
+            }
+        }
+    }
+
+    fun setDefaultStorageVolume(volumeId: String) {
+        viewModelScope.launch {
+            try {
+                preferencesRepository.setDownloadStorageVolumeId(volumeId)
+                _uiState.value = _uiState.value.copy(defaultStorageVolumeId = volumeId)
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to update default storage volume")
+            }
+        }
     }
 
     private fun loadDownloadPreferences() {
@@ -152,16 +188,82 @@ constructor(
                 val appStorageUsed = downloadRepository.getTotalStorageUsed()
                 val allServersStorageUsed = downloadRepository.getTotalStorageUsedAllServers()
                 val deviceStats = getDeviceStorageStats()
+                val perVolume = getPerVolumeStorageStats()
                 _uiState.value =
                     _uiState.value.copy(
                         totalStorageUsed = appStorageUsed,
                         totalStorageUsedAllServers = allServersStorageUsed,
                         deviceStorageStats = deviceStats,
+                        volumeStorageStats = perVolume,
                     )
             } catch (e: Exception) {
                 Timber.e(e, "Failed to load storage info")
             }
         }
+    }
+
+    private suspend fun getPerVolumeStorageStats(): List<VolumeStorageStats> {
+        val volumes = storageLocationProvider.listVolumes()
+        val usedThisServer = downloadRepository.getStorageUsedPerVolume()
+        val usedAllServers = downloadRepository.getStorageUsedPerVolumeAllServers()
+        val mountedStats =
+            volumes.mapNotNull { volume ->
+                val device =
+                    try {
+                        // StatFs throws on a non-existent path; ensure the base dir exists first.
+                        if (!volume.baseDir.exists()) volume.baseDir.mkdirs()
+                        val statPath =
+                            if (volume.baseDir.exists()) volume.baseDir
+                            else volume.baseDir.parentFile
+                        val stat = StatFs((statPath ?: volume.baseDir).path)
+                        val totalBytes = stat.totalBytes
+                        val availableBytes = stat.availableBytes
+                        DeviceStorageStats(
+                            totalBytes = totalBytes,
+                            freeBytes = availableBytes,
+                            usedBytes = totalBytes - availableBytes,
+                            usagePercentage =
+                                if (totalBytes > 0)
+                                    (totalBytes - availableBytes).toFloat() / totalBytes.toFloat()
+                                else 0f,
+                        )
+                    } catch (e: Exception) {
+                        Timber.w(e, "Failed to stat volume ${volume.id}")
+                        return@mapNotNull null
+                    }
+                VolumeStorageStats(
+                    volumeId = volume.id,
+                    displayName = volume.displayName,
+                    isRemovable = volume.isRemovable,
+                    isAvailable = true,
+                    usedThisServer = usedThisServer[volume.id] ?: 0L,
+                    usedAllServers = usedAllServers[volume.id] ?: 0L,
+                    device = device,
+                )
+            }
+
+        // Any volume that still has downloads recorded against it but is no longer mounted
+        // (e.g. an SD card that was removed) gets a synthetic "unavailable" card so the user can
+        // see the orphaned usage and manage those entries.
+        val mountedIds = mountedStats.map { it.volumeId }.toSet()
+        val unavailableStats =
+            (usedThisServer.keys + usedAllServers.keys)
+                .filter { it !in mountedIds }
+                .map { volumeId ->
+                    VolumeStorageStats(
+                        volumeId = volumeId,
+                        displayName =
+                            storageLocationProvider.displayNameFor(volumeId)
+                                ?: context.getString(R.string.storage_unavailable_volume),
+                        isRemovable = true,
+                        isAvailable = false,
+                        usedThisServer = usedThisServer[volumeId] ?: 0L,
+                        usedAllServers = usedAllServers[volumeId] ?: 0L,
+                        device = null,
+                    )
+                }
+
+        return mountedStats + unavailableStats
     }
 
     fun pauseDownload(downloadId: UUID) {
@@ -226,14 +328,47 @@ constructor(
                         loadStorageInfo()
                     }
                     .onFailure { error ->
-                        Timber.e(error, "Failed to delete download")
-                        _uiState.value =
-                            _uiState.value.copy(
-                                error = "Failed to delete download: ${error.message}"
-                            )
+                        if (error is VolumeUnavailableException) {
+                            // Files live on storage that isn't mounted; we can't delete them now.
+                            // Surface a confirmation so the user can drop the list entry anyway.
+                            Timber.w("Delete blocked: volume ${error.volumeId} unavailable")
+                            _uiState.value =
+                                _uiState.value.copy(pendingUnavailableDelete = downloadId)
+                        } else {
+                            Timber.e(error, "Failed to delete download")
+                            _uiState.value =
+                                _uiState.value.copy(
+                                    error = "Failed to delete download: ${error.message}"
+                                )
+                        }
                     }
             } catch (e: Exception) {
                 Timber.e(e, "Error deleting download")
+            }
+        }
+    }
+
+    fun dismissUnavailableDelete() {
+        _uiState.value = _uiState.value.copy(pendingUnavailableDelete = null)
+    }
+
+    fun confirmRemoveUnavailableDelete() {
+        val downloadId = _uiState.value.pendingUnavailableDelete ?: return
+        _uiState.value = _uiState.value.copy(pendingUnavailableDelete = null)
+        viewModelScope.launch {
+            try {
+                downloadRepository.removeDownloadRecord(downloadId)
+                    .onSuccess {
+                        Timber.i("Download record removed for unavailable volume")
+                        loadStorageInfo()
+                    }
+                    .onFailure { error ->
+                        Timber.e(error, "Failed to remove download record")
+                        _uiState.value =
+                            _uiState.value.copy(error = "Failed to remove entry: ${error.message}")
+                    }
+            } catch (e: Exception) {
+                Timber.e(e, "Error removing download record")
             }
         }
     }
@@ -314,6 +449,16 @@ constructor(
         val usagePercentage: Float,
     )
 
+    data class VolumeStorageStats(
+        val volumeId: String,
+        val displayName: String,
+        val isRemovable: Boolean,
+        val isAvailable: Boolean,
+        val usedThisServer: Long,
+        val usedAllServers: Long,
+        val device: DeviceStorageStats?,
+    )
+
     fun getDeviceStorageStats(): DeviceStorageStats {
         val path: File = Environment.getDataDirectory()
         val stat = StatFs(path.path)
@@ -342,5 +487,9 @@ data class DownloadsUiState(
     val isImageCacheEnabled: Boolean = true,
     val imageCacheSizeMb: Int = 512,
     val deviceStorageStats: DownloadsViewModel.DeviceStorageStats? = null,
+    val volumeStorageStats: List<DownloadsViewModel.VolumeStorageStats> = emptyList(),
+    val availableVolumes: List<StorageVolumeInfo> = emptyList(),
+    val defaultStorageVolumeId: String = StorageLocationProvider.PRIMARY_VOLUME_ID,
+    val pendingUnavailableDelete: UUID? = null,
     val error: String? = null,
 )

--- a/app/src/main/java/com/makd/afinity/ui/favorites/FavoritesScreen.kt
+++ b/app/src/main/java/com/makd/afinity/ui/favorites/FavoritesScreen.kt
@@ -270,10 +270,6 @@ fun FavoritesScreen(
         onToggleFavorite = { episode -> viewModel.toggleEpisodeFavorite(episode) },
         onToggleWatchlist = { episode -> viewModel.toggleEpisodeWatchlist(episode) },
         onToggleWatched = { episode -> viewModel.toggleEpisodeWatched(episode) },
-        onDownloadClick = { viewModel.onDownloadClick() },
-        onPauseDownload = { viewModel.pauseDownload() },
-        onResumeDownload = { viewModel.resumeDownload() },
-        onCancelDownload = { viewModel.cancelDownload() },
         onNavigateToSeries = { seriesId ->
             navController.navigate(
                 Destination.createItemDetailRoute(itemId = seriesId, itemType = "Series")

--- a/app/src/main/java/com/makd/afinity/ui/favorites/FavoritesViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/favorites/FavoritesViewModel.kt
@@ -19,7 +19,6 @@ import com.makd.afinity.data.repository.download.DownloadRepository
 import com.makd.afinity.data.repository.media.MediaRepository
 import com.makd.afinity.data.repository.userdata.UserDataRepository
 import com.makd.afinity.data.repository.watchlist.WatchlistRepository
-import com.makd.afinity.ui.item.delegates.ItemDownloadDelegate
 import com.makd.afinity.ui.item.delegates.ItemUserDataDelegate
 import com.makd.afinity.util.NetworkConnectivityMonitor
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -48,7 +47,6 @@ constructor(
     private val downloadRepository: DownloadRepository,
     private val appDataRepository: AppDataRepository,
     private val itemUserDataDelegate: ItemUserDataDelegate,
-    private val itemDownloadDelegate: ItemDownloadDelegate,
     private val preferencesRepository: PreferencesRepository,
     private val networkMonitor: NetworkConnectivityMonitor,
 ) : ViewModel() {
@@ -270,21 +268,6 @@ constructor(
             }
         }
     }
-
-    fun onDownloadClick() {
-        _selectedEpisode.value?.let { episode ->
-            itemDownloadDelegate.onDownloadClick(viewModelScope, episode) {}
-        }
-    }
-
-    fun pauseDownload() =
-        itemDownloadDelegate.pauseDownload(viewModelScope, _selectedEpisodeDownloadInfo.value)
-
-    fun resumeDownload() =
-        itemDownloadDelegate.resumeDownload(viewModelScope, _selectedEpisodeDownloadInfo.value)
-
-    fun cancelDownload() =
-        itemDownloadDelegate.cancelDownload(viewModelScope, _selectedEpisodeDownloadInfo.value)
 }
 
 data class FavoritesUiState(

--- a/app/src/main/java/com/makd/afinity/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/makd/afinity/ui/home/HomeScreen.kt
@@ -77,7 +77,6 @@ import com.makd.afinity.ui.home.components.ShowGenreSection
 import com.makd.afinity.ui.home.components.SpotlightCarousel
 import com.makd.afinity.ui.home.components.TvSeriesSectionSkeleton
 import com.makd.afinity.ui.home.components.UpcomingEpisodesSection
-import com.makd.afinity.ui.item.components.QualitySelectionDialog
 import com.makd.afinity.ui.main.MainUiState
 import com.makd.afinity.ui.utils.rememberTopBarOpacity
 import com.makd.afinity.ui.utils.verticalLayoutOffset
@@ -649,31 +648,11 @@ fun HomeScreen(
             onToggleFavorite = { episode -> viewModel.toggleEpisodeFavorite(episode) },
             onToggleWatchlist = { episode -> viewModel.toggleEpisodeWatchlist(episode) },
             onToggleWatched = { episode -> viewModel.toggleEpisodeWatched(episode) },
-            onDownloadClick = { viewModel.onDownloadClick() },
-            onPauseDownload = { viewModel.pauseDownload() },
-            onResumeDownload = { viewModel.resumeDownload() },
-            onCancelDownload = { viewModel.cancelDownload() },
             onNavigateToSeries = { seriesId ->
                 navController.navigate(
                     Destination.createItemDetailRoute(itemId = seriesId, itemType = "Series")
                 )
             },
         )
-
-        if (uiState.showQualityDialog) {
-            val currentEpisode = selectedEpisode
-            val remoteSources =
-                currentEpisode?.sources?.filter {
-                    it.type == com.makd.afinity.data.models.media.AfinitySourceType.REMOTE
-                } ?: emptyList()
-
-            if (remoteSources.isNotEmpty()) {
-                QualitySelectionDialog(
-                    sources = remoteSources,
-                    onSourceSelected = { source -> viewModel.onQualitySelected(source.id) },
-                    onDismiss = { viewModel.dismissQualityDialog() },
-                )
-            }
-        }
     }
 }

--- a/app/src/main/java/com/makd/afinity/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/makd/afinity/ui/home/HomeScreen.kt
@@ -293,6 +293,7 @@ fun HomeScreen(
                                         items = uiState.downloadedMovies,
                                         onItemClick = onItemClick,
                                         widthSizeClass = widthSizeClass,
+                                        unavailableItemIds = uiState.unavailableDownloadIds,
                                     )
                                 }
                             }
@@ -310,6 +311,7 @@ fun HomeScreen(
                                         items = uiState.downloadedShows,
                                         onItemClick = onItemClick,
                                         widthSizeClass = widthSizeClass,
+                                        unavailableItemIds = uiState.unavailableDownloadIds,
                                     )
                                 }
                             }

--- a/app/src/main/java/com/makd/afinity/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/home/HomeViewModel.kt
@@ -44,6 +44,7 @@ import com.makd.afinity.data.repository.download.DownloadRepository
 import com.makd.afinity.data.repository.media.MediaRepository
 import com.makd.afinity.data.repository.userdata.UserDataRepository
 import com.makd.afinity.data.repository.watchlist.WatchlistRepository
+import com.makd.afinity.data.storage.StorageLocationProvider
 import com.makd.afinity.data.workers.HomeDataReloadWorker
 import com.makd.afinity.navigation.Destination
 import com.makd.afinity.ui.item.delegates.ItemDownloadDelegate
@@ -93,6 +94,7 @@ constructor(
     private val databaseRepository: DatabaseRepository,
     private val downloadRepository: DownloadRepository,
     private val absDownloadRepository: AbsDownloadRepository,
+    private val storageLocationProvider: StorageLocationProvider,
     private val offlineModeManager: OfflineModeManager,
     private val authRepository: AuthRepository,
     private val mediaRepository: MediaRepository,
@@ -1063,6 +1065,16 @@ constructor(
             val completedDownloads = downloadRepository.getCompletedDownloadsFlow().first()
             val downloadedItemIds = completedDownloads.map { it.itemId }.toSet()
 
+            // A download is unavailable when the volume it was saved to (e.g. an SD card) is no
+            // longer mounted. Build the set of mounted volumes once and the per-item volume map so
+            // we can flag movies/shows whose files can't currently be reached.
+            val mountedVolumeIds = storageLocationProvider.mountedVolumeIds()
+            val volumeByItemId = completedDownloads.associate { it.itemId to it.storageVolumeId }
+            fun isItemUnavailable(itemId: UUID): Boolean {
+                val volumeId = volumeByItemId[itemId] ?: return false
+                return volumeId !in mountedVolumeIds
+            }
+
             val downloadedMovies =
                 databaseRepository.getAllMovies(userId).filter { movie ->
                     movie.id in downloadedItemIds
@@ -1128,6 +1140,25 @@ constructor(
                         )
                     }
 
+            // Movies are unavailable when their own download volume is gone; a show is unavailable
+            // only when every one of its downloaded episodes lives on a missing volume.
+            val unavailableMovieIds =
+                downloadedMovies.map { it.id }.filter { isItemUnavailable(it) }.toSet()
+            val unavailableShowIds =
+                downloadedShows
+                    .filter { show ->
+                        val downloadedEpisodeIds =
+                            show.seasons
+                                .flatMap { season -> season.episodes }
+                                .map { it.id }
+                                .filter { it in downloadedItemIds }
+                        downloadedEpisodeIds.isNotEmpty() &&
+                            downloadedEpisodeIds.all { isItemUnavailable(it) }
+                    }
+                    .map { it.id }
+                    .toSet()
+            val unavailableDownloadIds = unavailableMovieIds + unavailableShowIds
+
             _uiState.update {
                 it.copy(
                     downloadedMovies = downloadedMovies,
@@ -1135,6 +1166,7 @@ constructor(
                     offlineContinueWatching = sortedOfflineContinueWatching,
                     downloadedAudiobooks = downloadedAudiobooks,
                     downloadedPodcastEpisodes = downloadedPodcastEpisodes,
+                    unavailableDownloadIds = unavailableDownloadIds,
                 )
             }
         } catch (e: Exception) {
@@ -1463,6 +1495,7 @@ data class HomeUiState(
     val downloadedShows: List<AfinityShow> = emptyList(),
     val downloadedAudiobooks: List<AbsDownloadInfo> = emptyList(),
     val downloadedPodcastEpisodes: List<AbsDownloadInfo> = emptyList(),
+    val unavailableDownloadIds: Set<UUID> = emptySet(),
     val isLoading: Boolean = false,
     val error: String? = null,
     val combineLibrarySections: Boolean = false,

--- a/app/src/main/java/com/makd/afinity/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/home/HomeViewModel.kt
@@ -47,7 +47,6 @@ import com.makd.afinity.data.repository.watchlist.WatchlistRepository
 import com.makd.afinity.data.storage.StorageLocationProvider
 import com.makd.afinity.data.workers.HomeDataReloadWorker
 import com.makd.afinity.navigation.Destination
-import com.makd.afinity.ui.item.delegates.ItemDownloadDelegate
 import com.makd.afinity.ui.item.delegates.ItemUserDataDelegate
 import com.makd.afinity.ui.utils.IntentUtils
 import com.makd.afinity.util.NetworkConnectivityMonitor
@@ -101,7 +100,6 @@ constructor(
     private val playbackStateManager: PlaybackStateManager,
     private val adminChangeBroadcaster: AdminChangeBroadcaster,
     private val mediaChangeManager: MediaChangeManager,
-    private val itemDownloadDelegate: ItemDownloadDelegate,
     private val itemUserDataDelegate: ItemUserDataDelegate,
     private val preferencesRepository: PreferencesRepository,
     private val networkMonitor: NetworkConnectivityMonitor,
@@ -1249,36 +1247,6 @@ constructor(
         }
     }
 
-    fun onDownloadClick() {
-        itemDownloadDelegate.onDownloadClick(
-            scope = viewModelScope,
-            item = _selectedEpisode.value,
-            showQualityDialog = { _uiState.update { it.copy(showQualityDialog = true) } },
-        )
-    }
-
-    fun onQualitySelected(sourceId: String) {
-        itemDownloadDelegate.onQualitySelected(
-            scope = viewModelScope,
-            item = _selectedEpisode.value,
-            sourceId = sourceId,
-            hideQualityDialog = { dismissQualityDialog() },
-        )
-    }
-
-    fun dismissQualityDialog() {
-        _uiState.update { it.copy(showQualityDialog = false) }
-    }
-
-    fun pauseDownload() =
-        itemDownloadDelegate.pauseDownload(viewModelScope, _selectedEpisodeDownloadInfo.value)
-
-    fun resumeDownload() =
-        itemDownloadDelegate.resumeDownload(viewModelScope, _selectedEpisodeDownloadInfo.value)
-
-    fun cancelDownload() =
-        itemDownloadDelegate.cancelDownload(viewModelScope, _selectedEpisodeDownloadInfo.value)
-
     fun toggleEpisodeWatchlist(episode: AfinityEpisode) {
         viewModelScope.launch {
             try {
@@ -1504,5 +1472,4 @@ data class HomeUiState(
         emptyList(),
     val separateTvLibrarySections: List<Pair<AfinityCollection, List<AfinityShow>>> = emptyList(),
     val isOffline: Boolean = false,
-    val showQualityDialog: Boolean = false,
 )

--- a/app/src/main/java/com/makd/afinity/ui/home/components/HomeSections.kt
+++ b/app/src/main/java/com/makd/afinity/ui/home/components/HomeSections.kt
@@ -269,6 +269,7 @@ fun OptimizedLatestTvSeriesSection(
     onItemClick: (AfinityItem) -> Unit,
     widthSizeClass: WindowWidthSizeClass,
     title: String = stringResource(R.string.home_latest_tv_series),
+    unavailableItemIds: Set<java.util.UUID> = emptySet(),
 ) {
     val cardWidth = widthSizeClass.portraitWidth
     val cardHeight = CardDimensions.calculateHeight(cardWidth, CardDimensions.ASPECT_RATIO_PORTRAIT)
@@ -304,7 +305,12 @@ fun OptimizedLatestTvSeriesSection(
             contentPadding = PaddingValues(horizontal = 0.dp),
         ) {
             items(items = uniqueItems, key = { item -> "latest_tv_${item.id}" }) { item ->
-                MediaItemCard(item = item, onClick = { onItemClick(item) }, cardWidth = cardWidth)
+                MediaItemCard(
+                    item = item,
+                    onClick = { onItemClick(item) },
+                    cardWidth = cardWidth,
+                    isUnavailable = item.id in unavailableItemIds,
+                )
             }
         }
     }

--- a/app/src/main/java/com/makd/afinity/ui/item/ItemDetailScreen.kt
+++ b/app/src/main/java/com/makd/afinity/ui/item/ItemDetailScreen.kt
@@ -87,6 +87,7 @@ import com.makd.afinity.ui.item.components.BoxSetDetailContent
 import com.makd.afinity.ui.item.components.EpisodeDetailOverlay
 import com.makd.afinity.ui.item.components.MovieDetailContent
 import com.makd.afinity.ui.item.components.QualitySelectionDialog
+import com.makd.afinity.ui.item.components.StorageLocationDialog
 import com.makd.afinity.ui.item.components.SeasonDetailContent
 import com.makd.afinity.ui.item.components.SeriesDetailContent
 import com.makd.afinity.ui.item.components.VersionPickerDialog
@@ -307,8 +308,22 @@ fun ItemDetailScreen(
                     sources = remoteSources,
                     onSourceSelected = { source -> viewModel.onQualitySelected(source.id) },
                     onDismiss = { viewModel.dismissQualityDialog() },
+                    volumes = uiState.availableVolumes,
+                    selectedVolumeId = uiState.selectedVolumeId,
+                    onVolumeSelected = { viewModel.onVolumeSelected(it) },
+                    onConfirm = { source, _ -> viewModel.onQualitySelected(source.id) },
                 )
             }
+        }
+
+        if (uiState.showLocationDialog) {
+            StorageLocationDialog(
+                volumes = uiState.availableVolumes,
+                selectedVolumeId = uiState.selectedVolumeId,
+                onVolumeSelected = { viewModel.onVolumeSelected(it) },
+                onConfirm = { viewModel.onLocationConfirmed() },
+                onDismiss = { viewModel.dismissLocationDialog() },
+            )
         }
 
         if (showVersionPickerForPlay) {
@@ -464,6 +479,7 @@ private fun LandscapeItemDetailContent(
     widthSizeClass: WindowWidthSizeClass,
 ) {
     val preferencesRepository = rememberPreferencesRepository()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val canDownload by viewModel.canDownload.collectAsStateWithLifecycle()
     val isAdmin by viewModel.isAdmin.collectAsStateWithLifecycle()
     var showRefreshDialog by remember { mutableStateOf(false) }
@@ -592,7 +608,9 @@ private fun LandscapeItemDetailContent(
                                 onCancelDownload = { viewModel.cancelDownload() },
                                 canDownload = canDownload,
                                 isLandscape = true,
+                                downloadUnavailable = uiState.downloadUnavailable,
                                 isAdmin = isAdmin,
+                                onDownloadLongClick = { viewModel.onDownloadLongClick() },
                                 onAdminAction = { action ->
                                     when (action) {
                                         AdminAction.EditMetadata ->
@@ -699,6 +717,7 @@ private fun PortraitItemDetailContent(
 ) {
     val preferencesRepository = rememberPreferencesRepository()
     val bottomPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val canDownload by viewModel.canDownload.collectAsStateWithLifecycle()
     val isAdmin by viewModel.isAdmin.collectAsStateWithLifecycle()
     var showRefreshDialog by remember { mutableStateOf(false) }
@@ -765,7 +784,9 @@ private fun PortraitItemDetailContent(
                     onCancelDownload = { viewModel.cancelDownload() },
                     canDownload = canDownload,
                     isLandscape = false,
+                    downloadUnavailable = uiState.downloadUnavailable,
                     isAdmin = isAdmin,
+                    onDownloadLongClick = { viewModel.onDownloadLongClick() },
                     onAdminAction = { action ->
                         when (action) {
                             AdminAction.EditMetadata ->

--- a/app/src/main/java/com/makd/afinity/ui/item/ItemDetailViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/item/ItemDetailViewModel.kt
@@ -50,6 +50,8 @@ import com.makd.afinity.data.repository.download.DownloadRepository
 import com.makd.afinity.data.repository.media.MediaRepository
 import com.makd.afinity.data.repository.server.ServerRepository
 import com.makd.afinity.data.repository.userdata.UserDataRepository
+import com.makd.afinity.data.storage.StorageLocationProvider
+import com.makd.afinity.data.storage.StorageVolumeInfo
 import com.makd.afinity.ui.item.components.shared.MediaSourceOption
 import com.makd.afinity.ui.item.delegates.ItemDownloadDelegate
 import com.makd.afinity.ui.item.delegates.ItemUserDataDelegate
@@ -103,6 +105,7 @@ constructor(
     private val itemDownloadDelegate: ItemDownloadDelegate,
     private val itemUserDataDelegate: ItemUserDataDelegate,
     private val preferencesRepository: PreferencesRepository,
+    private val storageLocationProvider: StorageLocationProvider,
     private val networkMonitor: NetworkConnectivityMonitor,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
@@ -402,16 +405,48 @@ constructor(
                         _uiState.map { it.item }.distinctUntilChanged(),
                         downloadRepository.getAllDownloadsFlow(),
                     ) { item, downloads ->
-                        computeDownloadInfo(item, downloads)
+                        computeDownloadInfo(item, downloads) to
+                            computeDownloadUnavailable(item, downloads)
                     }
-                    .collect { downloadInfo ->
-                        _uiState.value = _uiState.value.copy(downloadInfo = downloadInfo)
+                    .collect { (downloadInfo, unavailable) ->
+                        _uiState.value =
+                            _uiState.value.copy(
+                                downloadInfo = downloadInfo,
+                                downloadUnavailable = unavailable,
+                            )
                     }
             } catch (e: Exception) {
                 if (e is CancellationException) throw e
                 Timber.e(e, "Failed to observe download status")
             }
         }
+    }
+
+    /**
+     * Whether the completed download(s) for [item] live on storage that is no longer mounted (e.g.
+     * an SD card was removed). For shows/seasons this is only true when *every* constituent
+     * completed download is on an unavailable volume, so a partially-available set still reads as
+     * available.
+     */
+    private fun computeDownloadUnavailable(
+        item: AfinityItem?,
+        downloads: List<DownloadInfo>,
+    ): Boolean {
+        if (item == null) return false
+        val relevant =
+            when (item) {
+                is AfinityShow -> downloads.filter { it.seriesId == item.id.toString() }
+                is AfinitySeason ->
+                    downloads.filter {
+                        it.seriesId == item.seriesId.toString() &&
+                            it.seasonNumber == item.indexNumber
+                    }
+                else -> downloads.filter { it.itemId == itemId }
+            }
+        val completed = relevant.filter { it.status == DownloadStatus.COMPLETED }
+        if (completed.isEmpty()) return false
+        val mounted = storageLocationProvider.mountedVolumeIds()
+        return completed.all { it.storageVolumeId !in mounted }
     }
 
     private fun computeDownloadInfo(
@@ -1163,7 +1198,7 @@ constructor(
                     viewModelScope,
                     selectedEpisode ?: currentItem,
                 ) {
-                    _uiState.value = _uiState.value.copy(showQualityDialog = true)
+                    showQualityDialogWithVolumes()
                 }
             }
             currentItem is AfinitySeason -> {
@@ -1189,11 +1224,99 @@ constructor(
         }
     }
 
+    /**
+     * Long-press entry point. Always opens the version/location dialog for the leaf item (movie or
+     * episode), even when there is a single version — letting the user pick a storage location.
+     * For bulk show/season downloads, opens a storage-location picker when more than one volume is
+     * available; otherwise falls back to the normal tap behavior.
+     */
+    fun onDownloadLongClick() {
+        val selectedEpisode = _selectedEpisode.value
+        val currentItem = _uiState.value.item
+        val leaf =
+            selectedEpisode
+                ?: currentItem?.takeIf { it !is AfinityShow && it !is AfinitySeason }
+        if (leaf != null) {
+            showQualityDialogWithVolumes()
+        } else {
+            showLocationDialogWithVolumes()
+        }
+    }
+
+    private fun showQualityDialogWithVolumes() {
+        viewModelScope.launch {
+            val volumes = storageLocationProvider.listVolumes()
+            val defaultVolumeId = preferencesRepository.getDownloadStorageVolumeId()
+            _uiState.value =
+                _uiState.value.copy(
+                    showQualityDialog = true,
+                    availableVolumes = volumes,
+                    selectedVolumeId = defaultVolumeId,
+                )
+        }
+    }
+
+    fun onVolumeSelected(volumeId: String) {
+        _uiState.value = _uiState.value.copy(selectedVolumeId = volumeId)
+    }
+
+    private fun showLocationDialogWithVolumes() {
+        viewModelScope.launch {
+            val volumes = storageLocationProvider.listVolumes()
+            if (volumes.size <= 1) {
+                onDownloadClick()
+                return@launch
+            }
+            val defaultVolumeId = preferencesRepository.getDownloadStorageVolumeId()
+            _uiState.value =
+                _uiState.value.copy(
+                    showLocationDialog = true,
+                    availableVolumes = volumes,
+                    selectedVolumeId = defaultVolumeId,
+                )
+        }
+    }
+
+    fun onLocationConfirmed() {
+        val volumeId = _uiState.value.selectedVolumeId
+        val currentItem = _uiState.value.item
+        dismissLocationDialog()
+        when (currentItem) {
+            is AfinitySeason -> {
+                bulkDownloadJob = viewModelScope.launch {
+                    downloadRepository
+                        .startSeasonDownload(currentItem.id, currentItem.seriesId, volumeId)
+                        .onSuccess { count ->
+                            Timber.i("Queued $count episodes for season ${currentItem.name}")
+                        }
+                        .onFailure { Timber.e(it, "Failed to start season download") }
+                }
+            }
+            is AfinityShow -> {
+                bulkDownloadJob = viewModelScope.launch {
+                    downloadRepository
+                        .startSeriesDownload(currentItem.id, volumeId)
+                        .onSuccess { count ->
+                            Timber.i("Queued $count episodes for series ${currentItem.name}")
+                        }
+                        .onFailure { Timber.e(it, "Failed to start series download") }
+                }
+            }
+            else -> {}
+        }
+    }
+
+    fun dismissLocationDialog() {
+        _uiState.value =
+            _uiState.value.copy(showLocationDialog = false, selectedVolumeId = null)
+    }
+
     fun onQualitySelected(sourceId: String) {
         itemDownloadDelegate.onQualitySelected(
             viewModelScope,
             _selectedEpisode.value ?: _uiState.value.item,
             sourceId,
+            _uiState.value.selectedVolumeId,
         ) {
             dismissQualityDialog()
         }
@@ -1391,7 +1514,8 @@ constructor(
     }
 
     fun dismissQualityDialog() {
-        _uiState.value = _uiState.value.copy(showQualityDialog = false)
+        _uiState.value =
+            _uiState.value.copy(showQualityDialog = false, selectedVolumeId = null)
     }
 
     fun getBaseUrl(): String = mediaRepository.getBaseUrl()
@@ -1424,7 +1548,11 @@ data class ItemDetailUiState(
     val nextEpisode: AfinityEpisode? = null,
     val episodesPagingData: Flow<PagingData<AfinityEpisode>>? = null,
     val showQualityDialog: Boolean = false,
+    val showLocationDialog: Boolean = false,
+    val availableVolumes: List<StorageVolumeInfo> = emptyList(),
+    val selectedVolumeId: String? = null,
     val downloadInfo: DownloadInfo? = null,
+    val downloadUnavailable: Boolean = false,
     val tmdbReviews: List<TmdbReview> = emptyList(),
     val isLoadingReviews: Boolean = false,
     val mdbRatings: List<MdbListRating> = emptyList(),

--- a/app/src/main/java/com/makd/afinity/ui/item/components/DownloadProgressIndicator.kt
+++ b/app/src/main/java/com/makd/afinity/ui/item/components/DownloadProgressIndicator.kt
@@ -1,17 +1,22 @@
 package com.makd.afinity.ui.item.components
 
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import com.makd.afinity.R
 import com.makd.afinity.data.models.download.DownloadInfo
@@ -26,6 +31,8 @@ fun DownloadProgressIndicator(
     onCancelClick: () -> Unit,
     canDownload: Boolean = true,
     isLandscape: Boolean = false,
+    isUnavailable: Boolean = false,
+    onDownloadLongClick: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     val isStartDownloadState = downloadInfo?.status == null ||
@@ -33,83 +40,129 @@ fun DownloadProgressIndicator(
         downloadInfo.status == DownloadStatus.CANCELLED
     val enabled = canDownload || !isStartDownloadState
 
-    IconButton(
-        onClick = {
-            when (downloadInfo?.status) {
-                null,
-                DownloadStatus.FAILED,
-                DownloadStatus.CANCELLED -> onDownloadClick()
-                DownloadStatus.DOWNLOADING,
-                DownloadStatus.QUEUED -> onCancelClick()
-                DownloadStatus.PAUSED -> onResumeClick()
-                DownloadStatus.COMPLETED -> onCancelClick()
-            }
-        },
-        enabled = enabled,
-        modifier = modifier,
-    ) {
+    val onClick: () -> Unit = {
         when (downloadInfo?.status) {
             null,
             DownloadStatus.FAILED,
-            DownloadStatus.CANCELLED -> {
-                Icon(
-                    painter = painterResource(id = R.drawable.ic_download),
-                    contentDescription = stringResource(R.string.action_download),
-                    tint = if (enabled) MaterialTheme.colorScheme.onBackground
-                           else MaterialTheme.colorScheme.onBackground.copy(alpha = 0.38f),
+            DownloadStatus.CANCELLED -> onDownloadClick()
+            DownloadStatus.DOWNLOADING,
+            DownloadStatus.QUEUED -> onCancelClick()
+            DownloadStatus.PAUSED -> onResumeClick()
+            DownloadStatus.COMPLETED -> onCancelClick()
+        }
+    }
+
+    // A long-press to choose a storage location only makes sense from the start-download state.
+    val longClick: (() -> Unit)? =
+        onDownloadLongClick?.takeIf { isStartDownloadState }
+
+    val content: @Composable () -> Unit = {
+        DownloadIndicatorContent(
+            downloadInfo = downloadInfo,
+            enabled = enabled,
+            isUnavailable = isUnavailable,
+        )
+    }
+
+    if (longClick != null) {
+        val interactionSource = remember { MutableInteractionSource() }
+        Box(
+            modifier =
+                modifier
+                    .size(48.dp)
+                    .combinedClickable(
+                        interactionSource = interactionSource,
+                        indication = ripple(bounded = false, radius = 24.dp),
+                        enabled = enabled,
+                        role = Role.Button,
+                        onClick = onClick,
+                        onLongClick = longClick,
+                    ),
+            contentAlignment = Alignment.Center,
+        ) {
+            content()
+        }
+    } else {
+        IconButton(onClick = onClick, enabled = enabled, modifier = modifier) { content() }
+    }
+}
+
+@Composable
+private fun DownloadIndicatorContent(
+    downloadInfo: DownloadInfo?,
+    enabled: Boolean,
+    isUnavailable: Boolean = false,
+) {
+    if (isUnavailable && downloadInfo?.status == DownloadStatus.COMPLETED) {
+        Icon(
+            painter = painterResource(id = R.drawable.ic_cloud_off),
+            contentDescription = stringResource(R.string.download_unavailable_indicator),
+            tint = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
+            modifier = Modifier.size(28.dp),
+        )
+        return
+    }
+    when (downloadInfo?.status) {
+        null,
+        DownloadStatus.FAILED,
+        DownloadStatus.CANCELLED -> {
+            Icon(
+                painter = painterResource(id = R.drawable.ic_download),
+                contentDescription = stringResource(R.string.action_download),
+                tint = if (enabled) MaterialTheme.colorScheme.onBackground
+                        else MaterialTheme.colorScheme.onBackground.copy(alpha = 0.38f),
+                modifier = Modifier.size(28.dp),
+            )
+        }
+
+        DownloadStatus.DOWNLOADING -> {
+            Box(contentAlignment = Alignment.Center) {
+                CircularProgressIndicator(
+                    progress = { downloadInfo.progress },
                     modifier = Modifier.size(28.dp),
+                    strokeWidth = 2.dp,
                 )
-            }
-
-            DownloadStatus.DOWNLOADING -> {
-                Box(contentAlignment = Alignment.Center) {
-                    CircularProgressIndicator(
-                        progress = { downloadInfo.progress },
-                        modifier = Modifier.size(28.dp),
-                        strokeWidth = 2.dp,
-                    )
-                    Icon(
-                        painter = painterResource(id = R.drawable.ic_cancel),
-                        contentDescription = stringResource(R.string.cd_cancel_download),
-                        modifier = Modifier.size(16.dp),
-                        tint = Color.Red,
-                    )
-                }
-            }
-
-            DownloadStatus.QUEUED -> {
                 Icon(
-                    painter = painterResource(id = R.drawable.ic_hourglass_empty),
-                    contentDescription = stringResource(R.string.cd_queued_tap_cancel),
-                    tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(28.dp),
-                )
-            }
-
-            DownloadStatus.PAUSED -> {
-                Box(contentAlignment = Alignment.Center) {
-                    CircularProgressIndicator(
-                        progress = { downloadInfo.progress },
-                        modifier = Modifier.size(28.dp),
-                        strokeWidth = 2.dp,
-                    )
-                    Icon(
-                        painter = painterResource(id = R.drawable.ic_cloud_pause),
-                        contentDescription = stringResource(R.string.cd_resume_download),
-                        modifier = Modifier.size(16.dp),
-                        tint = MaterialTheme.colorScheme.primary,
-                    )
-                }
-            }
-
-            DownloadStatus.COMPLETED -> {
-                Icon(
-                    painter = painterResource(id = R.drawable.ic_delete),
-                    contentDescription = stringResource(R.string.cd_delete_download),
+                    painter = painterResource(id = R.drawable.ic_cancel),
+                    contentDescription = stringResource(R.string.cd_cancel_download),
+                    modifier = Modifier.size(16.dp),
                     tint = Color.Red,
-                    modifier = Modifier.size(28.dp),
                 )
             }
+        }
+
+        DownloadStatus.QUEUED -> {
+            Icon(
+                painter = painterResource(id = R.drawable.ic_hourglass_empty),
+                contentDescription = stringResource(R.string.cd_queued_tap_cancel),
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(28.dp),
+            )
+        }
+
+        DownloadStatus.PAUSED -> {
+            Box(contentAlignment = Alignment.Center) {
+                CircularProgressIndicator(
+                    progress = { downloadInfo.progress },
+                    modifier = Modifier.size(28.dp),
+                    strokeWidth = 2.dp,
+                )
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_cloud_pause),
+                    contentDescription = stringResource(R.string.cd_resume_download),
+                    modifier = Modifier.size(16.dp),
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+            }
+        }
+
+        DownloadStatus.COMPLETED -> {
+            Icon(
+                painter = painterResource(id = R.drawable.ic_delete),
+                contentDescription = stringResource(R.string.cd_delete_download),
+                tint = Color.Red,
+                modifier = Modifier.size(28.dp),
+            )
         }
     }
 }

--- a/app/src/main/java/com/makd/afinity/ui/item/components/EpisodeDetailOverlay.kt
+++ b/app/src/main/java/com/makd/afinity/ui/item/components/EpisodeDetailOverlay.kt
@@ -85,6 +85,7 @@ fun EpisodeDetailOverlay(
     onResumeDownload: () -> Unit,
     onCancelDownload: () -> Unit,
     canDownload: Boolean = true,
+    onDownloadLongClick: (() -> Unit)? = null,
     onGoToSeries: (() -> Unit)? = null,
     isAdmin: Boolean = false,
     onAdminAction: (AdminAction) -> Unit = {},
@@ -520,6 +521,7 @@ fun EpisodeDetailOverlay(
                             onResumeClick = onResumeDownload,
                             onCancelClick = onCancelDownload,
                             canDownload = canDownload,
+                            onDownloadLongClick = onDownloadLongClick,
                         )
                     }
 

--- a/app/src/main/java/com/makd/afinity/ui/item/components/QualitySelectionDialog.kt
+++ b/app/src/main/java/com/makd/afinity/ui/item/components/QualitySelectionDialog.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import com.makd.afinity.R
 import com.makd.afinity.data.models.media.AfinitySource
+import com.makd.afinity.data.storage.StorageVolumeInfo
 
 @Composable
 fun QualitySelectionDialog(
@@ -38,8 +39,16 @@ fun QualitySelectionDialog(
     onSourceSelected: (AfinitySource) -> Unit,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
+    volumes: List<StorageVolumeInfo> = emptyList(),
+    selectedVolumeId: String? = null,
+    onVolumeSelected: (String) -> Unit = {},
+    onConfirm: (source: AfinitySource, volumeId: String?) -> Unit = { source, _ ->
+        onSourceSelected(source)
+    },
 ) {
-    var selectedSource by remember { mutableStateOf<AfinitySource?>(null) }
+    var selectedSource by
+        remember(sources) { mutableStateOf(sources.singleOrNull()) }
+    val showVolumePicker = volumes.size > 1
 
     Dialog(onDismissRequest = onDismiss) {
         Card(modifier = modifier.fillMaxWidth(), shape = RoundedCornerShape(16.dp)) {
@@ -73,6 +82,31 @@ fun QualitySelectionDialog(
                     }
                 }
 
+                if (showVolumePicker) {
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    Text(
+                        text = stringResource(R.string.download_location_section),
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Bold,
+                    )
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    LazyColumn(
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                        modifier = Modifier.weight(1f, fill = false),
+                    ) {
+                        items(volumes, key = { it.id }) { volume ->
+                            VolumeOption(
+                                volume = volume,
+                                isSelected = selectedVolumeId == volume.id,
+                                onSelect = { onVolumeSelected(volume.id) },
+                            )
+                        }
+                    }
+                }
+
                 Spacer(modifier = Modifier.height(16.dp))
 
                 Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
@@ -82,7 +116,7 @@ fun QualitySelectionDialog(
 
                     TextButton(
                         onClick = {
-                            selectedSource?.let { onSourceSelected(it) }
+                            selectedSource?.let { onConfirm(it, selectedVolumeId) }
                             onDismiss()
                         },
                         enabled = selectedSource != null,
@@ -90,6 +124,95 @@ fun QualitySelectionDialog(
                         Text(stringResource(R.string.action_download))
                     }
                 }
+            }
+        }
+    }
+}
+
+@Composable
+fun StorageLocationDialog(
+    volumes: List<StorageVolumeInfo>,
+    selectedVolumeId: String?,
+    onVolumeSelected: (String) -> Unit,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Dialog(onDismissRequest = onDismiss) {
+        Card(modifier = modifier.fillMaxWidth(), shape = RoundedCornerShape(16.dp)) {
+            Column(modifier = Modifier.padding(24.dp)) {
+                Text(
+                    text = stringResource(R.string.download_location_section),
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold,
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                LazyColumn(
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.weight(1f, fill = false),
+                ) {
+                    items(volumes, key = { it.id }) { volume ->
+                        VolumeOption(
+                            volume = volume,
+                            isSelected = selectedVolumeId == volume.id,
+                            onSelect = { onVolumeSelected(volume.id) },
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                    TextButton(onClick = onDismiss) { Text(stringResource(R.string.action_cancel)) }
+
+                    Spacer(modifier = Modifier.width(8.dp))
+
+                    TextButton(
+                        onClick = {
+                            onConfirm()
+                            onDismiss()
+                        },
+                        enabled = selectedVolumeId != null,
+                    ) {
+                        Text(stringResource(R.string.action_download))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun VolumeOption(
+    volume: StorageVolumeInfo,
+    isSelected: Boolean,
+    onSelect: () -> Unit,
+    modifier: Modifier = Modifier,
+) {    Surface(
+        onClick = onSelect,
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(8.dp),
+        color =
+            if (isSelected) MaterialTheme.colorScheme.primaryContainer
+            else MaterialTheme.colorScheme.surfaceVariant,
+        tonalElevation = 0.dp,
+    ) {
+        Row(modifier = Modifier.padding(16.dp), verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = volume.displayName,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+                modifier = Modifier.weight(1f),
+            )
+
+            if (isSelected) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_check),
+                    contentDescription = stringResource(R.string.cd_selected),
+                    tint = MaterialTheme.colorScheme.primary,
+                )
             }
         }
     }

--- a/app/src/main/java/com/makd/afinity/ui/item/components/shared/ActionButtonsRow.kt
+++ b/app/src/main/java/com/makd/afinity/ui/item/components/shared/ActionButtonsRow.kt
@@ -47,8 +47,10 @@ fun ActionButtonsRow(
     onCancelDownload: () -> Unit,
     canDownload: Boolean = true,
     isLandscape: Boolean = false,
+    downloadUnavailable: Boolean = false,
     isAdmin: Boolean = false,
     onAdminAction: (AdminAction) -> Unit = {},
+    onDownloadLongClick: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -138,6 +140,8 @@ fun ActionButtonsRow(
             onCancelClick = onCancelDownload,
             canDownload = canDownload && hasPlayableItems,
             isLandscape = isLandscape,
+            isUnavailable = downloadUnavailable,
+            onDownloadLongClick = onDownloadLongClick,
         )
 
         if (isAdmin) {

--- a/app/src/main/java/com/makd/afinity/ui/item/delegates/ItemDownloadDelegate.kt
+++ b/app/src/main/java/com/makd/afinity/ui/item/delegates/ItemDownloadDelegate.kt
@@ -3,13 +3,22 @@ package com.makd.afinity.ui.item.delegates
 import com.makd.afinity.data.models.download.DownloadInfo
 import com.makd.afinity.data.models.media.AfinityItem
 import com.makd.afinity.data.models.media.AfinitySourceType
+import com.makd.afinity.data.repository.PreferencesRepository
 import com.makd.afinity.data.repository.download.DownloadRepository
+import com.makd.afinity.data.storage.StorageLocationProvider
+import com.makd.afinity.data.storage.StorageVolumeInfo
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
 
-class ItemDownloadDelegate @Inject constructor(private val downloadRepository: DownloadRepository) {
+class ItemDownloadDelegate
+@Inject
+constructor(
+    private val downloadRepository: DownloadRepository,
+    private val storageLocationProvider: StorageLocationProvider,
+    private val preferencesRepository: PreferencesRepository,
+) {
     fun onDownloadClick(scope: CoroutineScope, item: AfinityItem?, showQualityDialog: () -> Unit) {
         val target = item ?: return
         scope.launch {
@@ -32,6 +41,35 @@ class ItemDownloadDelegate @Inject constructor(private val downloadRepository: D
             }
         }
     }
+
+    /**
+     * Long-press entry point for a single (leaf) item. Always opens the version/location picker when
+     * the item has remote sources, letting the user choose a quality version and/or a storage
+     * volume. The available volumes and current default are resolved off the main thread and handed
+     * back via [showPicker] so the caller can populate its dialog state.
+     */
+    fun onDownloadLongClick(
+        scope: CoroutineScope,
+        item: AfinityItem?,
+        showPicker: (volumes: List<StorageVolumeInfo>, defaultVolumeId: String?) -> Unit,
+    ) {
+        val target = item ?: return
+        scope.launch {
+            try {
+                val sources = target.sources.filter { it.type == AfinitySourceType.REMOTE }
+                if (sources.isEmpty()) {
+                    Timber.w("No remote sources available for download for item: ${target.name}")
+                    return@launch
+                }
+                val volumes = storageLocationProvider.listVolumes()
+                val defaultVolumeId = preferencesRepository.getDownloadStorageVolumeId()
+                showPicker(volumes, defaultVolumeId)
+            } catch (e: Exception) {
+                Timber.e(e, "Error preparing download options")
+            }
+        }
+    }
+
 
     fun onQualitySelected(
         scope: CoroutineScope,

--- a/app/src/main/java/com/makd/afinity/ui/item/delegates/ItemDownloadDelegate.kt
+++ b/app/src/main/java/com/makd/afinity/ui/item/delegates/ItemDownloadDelegate.kt
@@ -37,6 +37,7 @@ class ItemDownloadDelegate @Inject constructor(private val downloadRepository: D
         scope: CoroutineScope,
         item: AfinityItem?,
         sourceId: String,
+        volumeId: String? = null,
         hideQualityDialog: () -> Unit,
     ) {
         val target = item ?: return
@@ -44,7 +45,7 @@ class ItemDownloadDelegate @Inject constructor(private val downloadRepository: D
             try {
                 hideQualityDialog()
                 downloadRepository
-                    .startDownload(target.id, sourceId)
+                    .startDownload(target.id, sourceId, volumeId)
                     .onSuccess { Timber.i("Download started successfully for: ${target.name}") }
                     .onFailure { error -> Timber.e(error, "Failed to start download") }
             } catch (e: Exception) {

--- a/app/src/main/java/com/makd/afinity/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/makd/afinity/ui/search/SearchScreen.kt
@@ -362,10 +362,6 @@ fun SearchScreen(
             onToggleFavorite = { episode -> viewModel.toggleEpisodeFavorite(episode) },
             onToggleWatchlist = { episode -> viewModel.toggleEpisodeWatchlist(episode) },
             onToggleWatched = { episode -> viewModel.toggleEpisodeWatched(episode) },
-            onDownloadClick = { viewModel.onDownloadClick() },
-            onPauseDownload = { viewModel.pauseDownload() },
-            onResumeDownload = { viewModel.resumeDownload() },
-            onCancelDownload = { viewModel.cancelDownload() },
             onNavigateToSeries = { seriesId -> onSeriesClick(seriesId) },
         )
     }

--- a/app/src/main/java/com/makd/afinity/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/search/SearchViewModel.kt
@@ -35,7 +35,6 @@ import com.makd.afinity.data.repository.auth.AuthRepository
 import com.makd.afinity.data.repository.download.DownloadRepository
 import com.makd.afinity.data.repository.media.MediaRepository
 import com.makd.afinity.data.repository.userdata.UserDataRepository
-import com.makd.afinity.ui.item.delegates.ItemDownloadDelegate
 import com.makd.afinity.ui.item.delegates.ItemUserDataDelegate
 import com.makd.afinity.util.NetworkConnectivityMonitor
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -78,7 +77,6 @@ constructor(
     private val userDataRepository: UserDataRepository,
     private val authRepository: AuthRepository,
     private val databaseRepository: DatabaseRepository,
-    private val itemDownloadDelegate: ItemDownloadDelegate,
     private val itemUserDataDelegate: ItemUserDataDelegate,
     private val preferencesRepository: PreferencesRepository,
     private val networkMonitor: NetworkConnectivityMonitor,
@@ -262,21 +260,6 @@ constructor(
         _selectedEpisodeWatchlistStatus.value = false
         _selectedEpisodeDownloadInfo.value = null
     }
-
-    fun onDownloadClick() {
-        _selectedEpisode.value?.let { episode ->
-            itemDownloadDelegate.onDownloadClick(viewModelScope, episode) {}
-        }
-    }
-
-    fun pauseDownload() =
-        itemDownloadDelegate.pauseDownload(viewModelScope, _selectedEpisodeDownloadInfo.value)
-
-    fun resumeDownload() =
-        itemDownloadDelegate.resumeDownload(viewModelScope, _selectedEpisodeDownloadInfo.value)
-
-    fun cancelDownload() =
-        itemDownloadDelegate.cancelDownload(viewModelScope, _selectedEpisodeDownloadInfo.value)
 
     fun toggleEpisodeFavorite(episode: AfinityEpisode) {
         itemUserDataDelegate.toggleEpisodeFavorite(viewModelScope, episode) {

--- a/app/src/main/java/com/makd/afinity/ui/settings/downloads/DownloadSettingsScreen.kt
+++ b/app/src/main/java/com/makd/afinity/ui/settings/downloads/DownloadSettingsScreen.kt
@@ -3,6 +3,7 @@ package com.makd.afinity.ui.settings.downloads
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -24,6 +25,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -41,6 +43,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -53,6 +56,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalLocale
@@ -97,6 +101,24 @@ fun DownloadSettingsScreen(
             snackbarHostState.showSnackbar(error)
             viewModel.clearError()
         }
+    }
+
+    if (uiState.pendingUnavailableDelete != null) {
+        AlertDialog(
+            onDismissRequest = viewModel::dismissUnavailableDelete,
+            title = { Text(stringResource(R.string.download_unavailable_delete_title)) },
+            text = { Text(stringResource(R.string.download_unavailable_delete_message)) },
+            confirmButton = {
+                TextButton(onClick = viewModel::confirmRemoveUnavailableDelete) {
+                    Text(stringResource(R.string.download_unavailable_delete_confirm))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = viewModel::dismissUnavailableDelete) {
+                    Text(stringResource(R.string.action_cancel))
+                }
+            },
+        )
     }
 
     Scaffold(
@@ -166,11 +188,34 @@ fun DownloadSettingsScreen(
                     downloadCount = uiState.activeDownloads.size + uiState.completedDownloads.size,
                     isOffline = isOffline,
                     wifiOnly = uiState.downloadOverWifiOnly,
-                    deviceStats = uiState.deviceStorageStats,
+                    deviceStats =
+                        if (uiState.volumeStorageStats.size > 1)
+                            aggregateDeviceStats(uiState.volumeStorageStats)
+                        else uiState.deviceStorageStats,
                     onWifiOnlyChanged = viewModel::setDownloadOverWifiOnly,
                     formatSize = viewModel::formatStorageSize,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                 )
+            }
+
+            if (uiState.volumeStorageStats.size > 1) {
+                item {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    SectionHeader(
+                        title = stringResource(R.string.section_storage_locations),
+                        modifier = Modifier.padding(horizontal = 24.dp),
+                    )
+                }
+
+                item {
+                    StorageLocationsCard(
+                        stats = uiState.volumeStorageStats,
+                        defaultVolumeId = uiState.defaultStorageVolumeId,
+                        onSetDefault = viewModel::setDefaultStorageVolume,
+                        formatSize = viewModel::formatStorageSize,
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                    )
+                }
             }
 
             item {
@@ -249,8 +294,22 @@ fun DownloadSettingsScreen(
                     }
                     items(uiState.completedDownloads, key = { "jf_completed_${it.id}" }) { download
                         ->
+                        val unavailableVolumeIds =
+                            uiState.volumeStorageStats
+                                .filter { !it.isAvailable }
+                                .map { it.volumeId }
+                                .toSet()
+                        val isVolumeAvailable =
+                            download.storageVolumeId !in unavailableVolumeIds
                         CompletedDownloadRow(
                             download = download,
+                            volumeLabel =
+                                if (uiState.volumeStorageStats.size > 1)
+                                    uiState.volumeStorageStats
+                                        .firstOrNull { it.volumeId == download.storageVolumeId }
+                                        ?.displayName
+                                else null,
+                            isVolumeAvailable = isVolumeAvailable,
                             onDelete = viewModel::deleteDownload,
                             formatSize = viewModel::formatStorageSize,
                         )
@@ -388,9 +447,15 @@ fun StatusHub(
 
                     val freeSpaceText = deviceStats?.freeBytes?.let { formatSize(it) } ?: "..."
                     Text(
-                        text = stringResource(R.string.storage_free_on_device_fmt, freeSpaceText),
+                        text =
+                            stringResource(
+                                R.string.storage_free_on_device_fmt,
+                                freeSpaceText,
+                            ),
                         style =
-                            MaterialTheme.typography.bodySmall.copy(fontWeight = FontWeight.Medium),
+                            MaterialTheme.typography.bodySmall.copy(
+                                fontWeight = FontWeight.Medium
+                            ),
                         color =
                             if ((deviceStats?.usagePercentage ?: 0f) > 0.9f)
                                 MaterialTheme.colorScheme.error
@@ -653,6 +718,8 @@ fun ActiveDownloadCard(
 @Composable
 fun CompletedDownloadRow(
     download: DownloadInfo,
+    volumeLabel: String? = null,
+    isVolumeAvailable: Boolean = true,
     onDelete: (UUID) -> Unit,
     formatSize: (Long) -> String,
 ) {
@@ -685,7 +752,10 @@ fun CompletedDownloadRow(
                     else download.imageUrl,
                 contentDescription = null,
                 modifier =
-                    Modifier.width(56.dp).aspectRatio(2f / 3f).clip(RoundedCornerShape(6.dp)),
+                    Modifier.width(56.dp)
+                        .aspectRatio(2f / 3f)
+                        .clip(RoundedCornerShape(6.dp))
+                        .alpha(if (isVolumeAvailable) 1f else 0.4f),
                 contentScale = ContentScale.Crop,
             )
         },
@@ -698,13 +768,61 @@ fun CompletedDownloadRow(
             )
         },
         supportingContent = {
-            Text(
-                text = subtitleText,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
+            Column {
+                Text(
+                    text = subtitleText,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                if (!isVolumeAvailable) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.padding(top = 2.dp),
+                    ) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_folder),
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.size(14.dp),
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            text =
+                                stringResource(
+                                    R.string.download_unavailable_label,
+                                    volumeLabel
+                                        ?: stringResource(R.string.storage_unavailable_volume),
+                                ),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                } else if (volumeLabel != null) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.padding(top = 2.dp),
+                    ) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_folder),
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.size(14.dp),
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            text = volumeLabel,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+            }
         },
         trailingContent = {
             IconButton(onClick = { onDelete(download.id) }) {
@@ -726,6 +844,188 @@ fun SectionHeader(title: String, modifier: Modifier = Modifier) {
         color = MaterialTheme.colorScheme.primary,
         fontWeight = FontWeight.Bold,
         modifier = modifier,
+    )
+}
+
+@Composable
+fun StorageLocationsCard(
+    stats: List<DownloadsViewModel.VolumeStorageStats>,
+    defaultVolumeId: String,
+    onSetDefault: (String) -> Unit,
+    formatSize: (Long) -> String,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+    ) {
+        Column {
+            stats.forEachIndexed { index, item ->
+                if (index > 0) {
+                    HorizontalDivider(
+                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f),
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                    )
+                }
+                VolumeStorageRow(
+                    stats = item,
+                    isDefault = item.isAvailable && item.volumeId == defaultVolumeId,
+                    onSetDefault = { if (item.isAvailable) onSetDefault(item.volumeId) },
+                    formatSize = formatSize,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun VolumeStorageRow(
+    stats: DownloadsViewModel.VolumeStorageStats,
+    isDefault: Boolean,
+    onSetDefault: () -> Unit,
+    formatSize: (Long) -> String,
+) {
+    val device = stats.device
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier =
+            Modifier.fillMaxWidth()
+                .clickable(enabled = stats.isAvailable, onClick = onSetDefault)
+                .background(
+                    if (isDefault) MaterialTheme.colorScheme.primary.copy(alpha = 0.06f)
+                    else Color.Transparent
+                )
+                .padding(16.dp),
+    ) {
+        Box(contentAlignment = Alignment.Center, modifier = Modifier.size(56.dp)) {
+            CircularProgressIndicator(
+                progress = { 1f },
+                modifier = Modifier.fillMaxSize(),
+                color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                strokeWidth = 5.dp,
+            )
+            if (device != null) {
+                val progress = device.usagePercentage
+                CircularProgressIndicator(
+                    progress = { progress },
+                    modifier = Modifier.fillMaxSize(),
+                    color =
+                        if (progress > 0.9f) MaterialTheme.colorScheme.error
+                        else MaterialTheme.colorScheme.primary,
+                    strokeWidth = 5.dp,
+                    strokeCap = StrokeCap.Round,
+                )
+            }
+            Icon(
+                painter =
+                    painterResource(
+                        id =
+                            if (stats.isRemovable) R.drawable.ic_folder
+                            else R.drawable.ic_database
+                    ),
+                contentDescription = null,
+                tint =
+                    if (stats.isAvailable) MaterialTheme.colorScheme.primary
+                    else MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(20.dp),
+            )
+        }
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        Column(modifier = Modifier.weight(1f)) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(
+                    text = stats.displayName,
+                    style =
+                        MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                    color =
+                        if (stats.isAvailable) MaterialTheme.colorScheme.onSurface
+                        else MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                if (!stats.isAvailable) {
+                    Surface(
+                        shape = RoundedCornerShape(50),
+                        color = MaterialTheme.colorScheme.surfaceContainerHighest,
+                    ) {
+                        Text(
+                            text = stringResource(R.string.storage_unavailable_badge),
+                            style =
+                                MaterialTheme.typography.labelMedium.copy(
+                                    fontWeight = FontWeight.Bold
+                                ),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
+                        )
+                    }
+                } else if (isDefault) {
+                    Surface(
+                        shape = RoundedCornerShape(50),
+                        color = MaterialTheme.colorScheme.primary,
+                    ) {
+                        Text(
+                            text = stringResource(R.string.storage_default_badge),
+                            style =
+                                MaterialTheme.typography.labelMedium.copy(
+                                    fontWeight = FontWeight.Bold
+                                ),
+                            color = MaterialTheme.colorScheme.onPrimary,
+                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
+                        )
+                    }
+                } else {
+                    Text(
+                        text = stringResource(R.string.storage_set_as_default),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            Text(
+                text =
+                    if (device != null)
+                        stringResource(
+                            R.string.storage_usage_combined_fmt,
+                            formatSize(stats.usedThisServer),
+                            formatSize(device.freeBytes),
+                            formatSize(device.totalBytes),
+                        )
+                    else
+                        stringResource(
+                            R.string.storage_unavailable_used_fmt,
+                            formatSize(stats.usedThisServer),
+                        ),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+private fun aggregateDeviceStats(
+    stats: List<DownloadsViewModel.VolumeStorageStats>
+): DownloadsViewModel.DeviceStorageStats? {
+    val devices = stats.mapNotNull { it.device }
+    if (devices.isEmpty()) return null
+    val totalBytes = devices.sumOf { it.totalBytes }
+    val freeBytes = devices.sumOf { it.freeBytes }
+    val usedBytes = totalBytes - freeBytes
+    return DownloadsViewModel.DeviceStorageStats(
+        totalBytes = totalBytes,
+        freeBytes = freeBytes,
+        usedBytes = usedBytes,
+        usagePercentage = if (totalBytes > 0) usedBytes.toFloat() / totalBytes.toFloat() else 0f,
     )
 }
 

--- a/app/src/main/java/com/makd/afinity/ui/watchlist/WatchlistScreen.kt
+++ b/app/src/main/java/com/makd/afinity/ui/watchlist/WatchlistScreen.kt
@@ -213,10 +213,6 @@ fun WatchlistScreen(
         onToggleFavorite = { episode -> viewModel.toggleEpisodeFavorite(episode) },
         onToggleWatchlist = { episode -> viewModel.toggleEpisodeWatchlist(episode) },
         onToggleWatched = { episode -> viewModel.toggleEpisodeWatched(episode) },
-        onDownloadClick = { viewModel.onDownloadClick() },
-        onPauseDownload = { viewModel.pauseDownload() },
-        onResumeDownload = { viewModel.resumeDownload() },
-        onCancelDownload = { viewModel.cancelDownload() },
         onNavigateToSeries = { seriesId ->
             navController.navigate(
                 Destination.createItemDetailRoute(itemId = seriesId, itemType = "Series")

--- a/app/src/main/java/com/makd/afinity/ui/watchlist/WatchlistViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/watchlist/WatchlistViewModel.kt
@@ -19,7 +19,6 @@ import com.makd.afinity.data.repository.download.DownloadRepository
 import com.makd.afinity.data.repository.media.MediaRepository
 import com.makd.afinity.data.repository.userdata.UserDataRepository
 import com.makd.afinity.data.repository.watchlist.WatchlistRepository
-import com.makd.afinity.ui.item.delegates.ItemDownloadDelegate
 import com.makd.afinity.ui.item.delegates.ItemUserDataDelegate
 import com.makd.afinity.util.NetworkConnectivityMonitor
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -47,7 +46,6 @@ constructor(
     private val adminChangeBroadcaster: AdminChangeBroadcaster,
     private val mediaChangeManager: MediaChangeManager,
     private val itemUserDataDelegate: ItemUserDataDelegate,
-    private val itemDownloadDelegate: ItemDownloadDelegate,
     private val preferencesRepository: PreferencesRepository,
     private val networkMonitor: NetworkConnectivityMonitor,
 ) : ViewModel() {
@@ -195,21 +193,6 @@ constructor(
             }
         }
     }
-
-    fun onDownloadClick() {
-        _selectedEpisode.value?.let { episode ->
-            itemDownloadDelegate.onDownloadClick(viewModelScope, episode) {}
-        }
-    }
-
-    fun pauseDownload() =
-        itemDownloadDelegate.pauseDownload(viewModelScope, _selectedEpisodeDownloadInfo.value)
-
-    fun resumeDownload() =
-        itemDownloadDelegate.resumeDownload(viewModelScope, _selectedEpisodeDownloadInfo.value)
-
-    fun cancelDownload() =
-        itemDownloadDelegate.cancelDownload(viewModelScope, _selectedEpisodeDownloadInfo.value)
 }
 
 data class WatchlistUiState(

--- a/app/src/main/java/com/makd/afinity/util/ComposeHiltExt.kt
+++ b/app/src/main/java/com/makd/afinity/util/ComposeHiltExt.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 import com.makd.afinity.data.repository.PreferencesRepository
+import com.makd.afinity.ui.item.delegates.ItemDownloadDelegate
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
@@ -21,4 +22,21 @@ fun rememberPreferencesRepository(
 ): PreferencesRepository {
     return EntryPointAccessors.fromApplication(context, PreferencesRepositoryEntryPoint::class.java)
         .preferencesRepository()
+}
+
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface ItemDownloadDelegateEntryPoint {
+    fun itemDownloadDelegate(): ItemDownloadDelegate
+}
+
+@Composable
+fun rememberItemDownloadDelegate(
+    context: Context = LocalContext.current.applicationContext
+): ItemDownloadDelegate {
+    return EntryPointAccessors.fromApplication(
+            context,
+            ItemDownloadDelegateEntryPoint::class.java,
+        )
+        .itemDownloadDelegate()
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -475,6 +475,21 @@
     <string name="storage_free_on_device_fmt">%1$s free on device</string>
     <string name="storage_this_server">This server</string>
     <string name="storage_all_servers_fmt">%1$s total across all servers</string>
+    <string name="section_storage_locations">STORAGE LOCATIONS</string>
+    <string name="storage_used_on_volume_fmt">%1$s used on this server</string>
+    <string name="storage_free_of_total_fmt">%1$s free of %2$s</string>
+    <string name="storage_usage_combined_fmt">%1$s used here • %2$s free of %3$s</string>
+    <string name="storage_default_badge">Default</string>
+    <string name="storage_set_as_default">Set as default</string>
+    <string name="storage_unavailable_volume">Unavailable storage</string>
+    <string name="storage_unavailable_badge">Unavailable</string>
+    <string name="storage_unavailable_used_fmt">%1$s used • storage not connected</string>
+    <string name="download_unavailable_label">Unavailable — %1$s removed</string>
+    <string name="download_unavailable_indicator">Downloaded — storage unavailable</string>
+    <string name="download_unavailable_delete_title">Storage unavailable</string>
+    <string name="download_unavailable_delete_message">This download is on storage that isn\'t connected, so its files can\'t be deleted right now. Remove it from the list anyway? The files will remain on the storage if you reconnect it.</string>
+    <string name="download_unavailable_delete_confirm">Remove from list</string>
+    <string name="download_location_section">Storage location</string>
 
     <string name="download_preferences_title">Download Settings</string>
     <string name="pref_download_wifi_only_title">Wi-Fi only</string>


### PR DESCRIPTION
Sorry for the massive PR, but I've been wanting support for downloading to external storage and I took a stab at implementing it.

On the database side, the main change is the addition of a `storageVolumeId` to `DownloadDto` to keep track of which volume the item is downloaded to. For any downloads to internal storage (and therefore, any existing downloads), this will be the string `primary`, otherwise it will be the uuid of the storage volume.

On the UX side, the Downloads & Storage page is updated to show total device usage at the top, along with usage per storage volume under a new "Storage Locations" section, which can also be used to select the default download location.

The version selection UX can now also be used to select a different storage location if you want to manually choose somewhere other than the default.

I also tried to gracefully handle the case where the external storage volume is unmounted so that it's clear when things aren't available in the UX.

Also note that the new UX features only show up on devices which actually have external storage available, so for devices without an SD card, the experience should be the same as today.

Download selection:
<img width="2800" height="1752" alt="download-selection" src="https://github.com/user-attachments/assets/92621216-fe0e-43c5-8aed-07f1cfc6810d" />

Downloading:
<img width="2800" height="1752" alt="downloading" src="https://github.com/user-attachments/assets/c0a27111-4b5d-4bf3-ae24-090d98a0cc7a" />

Downloads & Storage page:
<img width="2800" height="1752" alt="Screenshot_20260607_230845_AFinity" src="https://github.com/user-attachments/assets/91ea2c26-d088-4cf1-b0db-dff66892430d" />

Completed download showing location:
<img width="2800" height="1752" alt="Screenshot_20260607_235202_AFinity" src="https://github.com/user-attachments/assets/7988b02c-6bcc-43cd-9863-35c8d7e95b27" />

Completed download when volume is unmounted:
<img width="2800" height="1752" alt="Screenshot_20260607_230937_AFinity" src="https://github.com/user-attachments/assets/9ce5de87-8314-43d3-bc66-f91615bbb785" />
