### PR TITLE
fix: fix a race condition causing a blank home screen when offline

### DIFF
--- a/app/src/main/java/com/makd/afinity/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/home/HomeViewModel.kt
@@ -66,7 +66,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -74,7 +74,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeoutOrNull
 import org.jellyfin.sdk.model.api.PersonKind.ACTOR
 import org.jellyfin.sdk.model.api.PersonKind.DIRECTOR
 import org.jellyfin.sdk.model.api.PersonKind.WRITER
@@ -164,7 +163,6 @@ constructor(
                             launch { loadUpcomingEpisodes() }
                         }
                         loadNewHomescreenSections()
-                        loadDownloadedContent()
                     }
                 }
             }
@@ -293,12 +291,26 @@ constructor(
                 Timber.d("Offline mode changed: $isOffline")
                 _uiState.update { it.copy(isOffline = isOffline) }
 
-                if (isOffline) {
-                    loadDownloadedContent()
-                } else {
+                if (!isOffline) {
                     scheduleHomeDataReload()
                 }
             }
+        }
+
+        // Load downloaded content whenever we're offline and a user is available. Combining the two
+        // flows means we react once the user is known rather than reading it eagerly and racing the
+        // session restore (which would leave the offline home blank). distinctUntilChanged avoids
+        // reloading on the redundant emissions both source flows produce during startup.
+        viewModelScope.launch {
+            combine(offlineModeManager.isOffline, authRepository.currentUser) { isOffline, user ->
+                    isOffline to user?.id
+                }
+                .distinctUntilChanged()
+                .collect { (isOffline, userId) ->
+                    if (isOffline && userId != null) {
+                        loadDownloadedContent(userId)
+                    }
+                }
         }
 
         viewModelScope.launch {
@@ -1056,22 +1068,8 @@ constructor(
         return adjustedPositions
     }
 
-    private suspend fun loadDownloadedContent() {
+    private suspend fun loadDownloadedContent(userId: UUID) {
         try {
-            // Wait for the current user to be available before loading. Right after an offline
-            // session restore it can briefly be null, so awaiting it (with a timeout safeguard)
-            // avoids bailing out early and leaving the offline home blank.
-            val userId =
-                withTimeoutOrNull(10_000) {
-                    authRepository.currentUser.filterNotNull().first().id
-                }
-                    ?: run {
-                        Timber.w(
-                            "No authenticated user available; skipping downloaded content load"
-                        )
-                        return
-                    }
-
             Timber.d("Loading downloaded content for user: $userId")
 
             val completedDownloads = downloadRepository.getCompletedDownloadsFlow().first()

--- a/app/src/main/java/com/makd/afinity/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/home/HomeViewModel.kt
@@ -66,6 +66,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -73,6 +74,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import org.jellyfin.sdk.model.api.PersonKind.ACTOR
 import org.jellyfin.sdk.model.api.PersonKind.DIRECTOR
 import org.jellyfin.sdk.model.api.PersonKind.WRITER
@@ -1056,7 +1058,19 @@ constructor(
 
     private suspend fun loadDownloadedContent() {
         try {
-            val userId = authRepository.currentUser.value?.id ?: return
+            // Wait for the current user to be available before loading. Right after an offline
+            // session restore it can briefly be null, so awaiting it (with a timeout safeguard)
+            // avoids bailing out early and leaving the offline home blank.
+            val userId =
+                withTimeoutOrNull(10_000) {
+                    authRepository.currentUser.filterNotNull().first().id
+                }
+                    ?: run {
+                        Timber.w(
+                            "No authenticated user available; skipping downloaded content load"
+                        )
+                        return
+                    }
 
             Timber.d("Loading downloaded content for user: $userId")
 


### PR DESCRIPTION
When cold starting the app offline, there is a race condition which causes the home screen to just render a blank screen, rather than showing the downloaded content.

<img width="270" alt="repro" src="https://github.com/user-attachments/assets/5db73f96-dbdb-4924-a571-32447e2d89c2" />

If `authRepository.currentUser.value?.id` is null when `loadDownloadedContent` runs, we skip the entire thing and end up rendering nothing, and, unfortunately, that value might not be initialized yet when `loadDownloadedContent` runs. In my testing, this race was obvious when completely offline (e.g. airplane mode with no wifi or connection to the server), leading to the blank screen more than 50% of the time.

When running in "Offline Mode" but still connected to the server, the app does more initialization before attempting to `loadDownloadedContent`, so generally you don't see this race. I also saw the race less frequently when testing in the debug build, so this was only obvious in the release build.

The fix here will wait for the `authRepository.currentUser` to be populated for 10 seconds (really overkill, it should never take this long in practice, so this would likely only happen because of some other bug) before giving up and skipping the load.

Repro steps:
1. Start online with a connection to the server
2. Download some content locally
3. Fully close the app (e.g. swipe up on the app in the App Switcher to close it)
4. Fully disconnect (e.g. wifi off, airplane mode on)
5. Open the app

Because it's a race, it's possible it might not repro every time, so repeat several times until you see it show a blank home screen instead of the downloaded content.