### PR TITLE
feat: rework audio and subtitle track selection

### DIFF
--- a/app/src/main/java/com/makd/afinity/data/manager/SessionManager.kt
+++ b/app/src/main/java/com/makd/afinity/data/manager/SessionManager.kt
@@ -29,6 +29,7 @@ import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.exception.InvalidStatusException
 import org.jellyfin.sdk.api.okhttp.OkHttpFactory
 import org.jellyfin.sdk.api.operations.UserApi
+import org.jellyfin.sdk.model.api.UserConfiguration
 import timber.log.Timber
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
@@ -44,6 +45,7 @@ data class Session(
     val user: User? = null,
     val server: Server? = null,
     val isAdmin: Boolean? = null,
+    val userConfiguration: UserConfiguration? = null,
 )
 
 @Singleton
@@ -204,7 +206,11 @@ constructor(
                         val current = _currentSession.value
                         if (current?.serverId == serverId && current.userId == userId) {
                             _currentSession.value =
-                                current.copy(isAdmin = isAdmin, user = refreshedUser)
+                                current.copy(
+                                    isAdmin = isAdmin,
+                                    user = refreshedUser,
+                                    userConfiguration = userDto.configuration,
+                                )
                         }
                         Timber.d("Admin status refreshed from policy: isAdmin=$isAdmin")
                     } catch (e: Exception) {

--- a/app/src/main/java/com/makd/afinity/data/models/media/AfinityMediaStream.kt
+++ b/app/src/main/java/com/makd/afinity/data/models/media/AfinityMediaStream.kt
@@ -49,6 +49,7 @@ fun MediaStream.toAfinityMediaStream(baseUrl: String): AfinityMediaStream {
         channels = channels,
         isDefault = isDefault,
         isForced = isForced,
+        isHearingImpaired = isHearingImpaired,
         profile = profile,
     )
 }

--- a/app/src/main/java/com/makd/afinity/data/repository/PreferencesRepository.kt
+++ b/app/src/main/java/com/makd/afinity/data/repository/PreferencesRepository.kt
@@ -134,6 +134,12 @@ interface PreferencesRepository {
 
     fun getPreferredSubtitleLanguageFlow(): Flow<String>
 
+    suspend fun setSubtitleModeOverride(mode: String)
+
+    suspend fun getSubtitleModeOverride(): String
+
+    fun getSubtitleModeOverrideFlow(): Flow<String>
+
     suspend fun setThemeMode(mode: String)
 
     suspend fun getThemeMode(): String

--- a/app/src/main/java/com/makd/afinity/data/repository/PreferencesRepository.kt
+++ b/app/src/main/java/com/makd/afinity/data/repository/PreferencesRepository.kt
@@ -140,6 +140,12 @@ interface PreferencesRepository {
 
     fun getSubtitleModeOverrideFlow(): Flow<String>
 
+    suspend fun setPreferSdhSubtitles(enabled: Boolean)
+
+    suspend fun getPreferSdhSubtitles(): Boolean
+
+    fun getPreferSdhSubtitlesFlow(): Flow<Boolean>
+
     suspend fun setThemeMode(mode: String)
 
     suspend fun getThemeMode(): String

--- a/app/src/main/java/com/makd/afinity/data/repository/impl/PreferencesRepositoryImpl.kt
+++ b/app/src/main/java/com/makd/afinity/data/repository/impl/PreferencesRepositoryImpl.kt
@@ -124,6 +124,7 @@ constructor(@param:AppPreferences private val dataStore: DataStore<Preferences>)
 
         val PREFERRED_AUDIO_LANGUAGE = stringPreferencesKey("preferred_audio_language")
         val PREFERRED_SUBTITLE_LANGUAGE = stringPreferencesKey("preferred_subtitle_language")
+        val SUBTITLE_MODE_OVERRIDE = stringPreferencesKey("subtitle_mode_override")
 
         val NOTIFICATION_PERMISSION_DECLINED =
             booleanPreferencesKey("notification_permission_declined")
@@ -703,6 +704,18 @@ constructor(@param:AppPreferences private val dataStore: DataStore<Preferences>)
         return dataStore.data.map { preferences ->
             preferences[Keys.PREFERRED_SUBTITLE_LANGUAGE] ?: ""
         }
+    }
+
+    override suspend fun setSubtitleModeOverride(mode: String) {
+        dataStore.edit { preferences -> preferences[Keys.SUBTITLE_MODE_OVERRIDE] = mode }
+    }
+
+    override suspend fun getSubtitleModeOverride(): String {
+        return dataStore.data.first()[Keys.SUBTITLE_MODE_OVERRIDE] ?: ""
+    }
+
+    override fun getSubtitleModeOverrideFlow(): Flow<String> {
+        return dataStore.data.map { preferences -> preferences[Keys.SUBTITLE_MODE_OVERRIDE] ?: "" }
     }
 
     override suspend fun setPipGestureEnabled(enabled: Boolean) {

--- a/app/src/main/java/com/makd/afinity/data/repository/impl/PreferencesRepositoryImpl.kt
+++ b/app/src/main/java/com/makd/afinity/data/repository/impl/PreferencesRepositoryImpl.kt
@@ -126,6 +126,7 @@ constructor(@param:AppPreferences private val dataStore: DataStore<Preferences>)
         val PREFERRED_AUDIO_LANGUAGE = stringPreferencesKey("preferred_audio_language")
         val PREFERRED_SUBTITLE_LANGUAGE = stringPreferencesKey("preferred_subtitle_language")
         val SUBTITLE_MODE_OVERRIDE = stringPreferencesKey("subtitle_mode_override")
+        val PREFER_SDH_SUBTITLES = booleanPreferencesKey("prefer_sdh_subtitles")
 
         val NOTIFICATION_PERMISSION_DECLINED =
             booleanPreferencesKey("notification_permission_declined")
@@ -719,6 +720,18 @@ constructor(@param:AppPreferences private val dataStore: DataStore<Preferences>)
 
     override fun getSubtitleModeOverrideFlow(): Flow<String> {
         return dataStore.data.map { preferences -> preferences[Keys.SUBTITLE_MODE_OVERRIDE] ?: "" }
+    }
+
+    override suspend fun setPreferSdhSubtitles(enabled: Boolean) {
+        dataStore.edit { preferences -> preferences[Keys.PREFER_SDH_SUBTITLES] = enabled }
+    }
+
+    override suspend fun getPreferSdhSubtitles(): Boolean {
+        return dataStore.data.first()[Keys.PREFER_SDH_SUBTITLES] ?: false
+    }
+
+    override fun getPreferSdhSubtitlesFlow(): Flow<Boolean> {
+        return dataStore.data.map { preferences -> preferences[Keys.PREFER_SDH_SUBTITLES] ?: false }
     }
 
     override suspend fun setPipGestureEnabled(enabled: Boolean) {

--- a/app/src/main/java/com/makd/afinity/data/repository/impl/PreferencesRepositoryImpl.kt
+++ b/app/src/main/java/com/makd/afinity/data/repository/impl/PreferencesRepositoryImpl.kt
@@ -26,6 +26,7 @@ import com.makd.afinity.data.models.player.SubtitleVerticalPosition
 import com.makd.afinity.data.models.player.VideoZoomMode
 import com.makd.afinity.data.repository.PreferencesRepository
 import com.makd.afinity.di.AppPreferences
+import com.makd.afinity.player.common.TrackSelection
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
@@ -683,12 +684,13 @@ constructor(@param:AppPreferences private val dataStore: DataStore<Preferences>)
     }
 
     override suspend fun getPreferredAudioLanguage(): String {
-        return dataStore.data.first()[Keys.PREFERRED_AUDIO_LANGUAGE] ?: ""
+        return dataStore.data.first()[Keys.PREFERRED_AUDIO_LANGUAGE]
+            ?: TrackSelection.FOLLOW_SERVER_LANGUAGE
     }
 
     override fun getPreferredAudioLanguageFlow(): Flow<String> {
         return dataStore.data.map { preferences ->
-            preferences[Keys.PREFERRED_AUDIO_LANGUAGE] ?: ""
+            preferences[Keys.PREFERRED_AUDIO_LANGUAGE] ?: TrackSelection.FOLLOW_SERVER_LANGUAGE
         }
     }
 
@@ -697,12 +699,13 @@ constructor(@param:AppPreferences private val dataStore: DataStore<Preferences>)
     }
 
     override suspend fun getPreferredSubtitleLanguage(): String {
-        return dataStore.data.first()[Keys.PREFERRED_SUBTITLE_LANGUAGE] ?: ""
+        return dataStore.data.first()[Keys.PREFERRED_SUBTITLE_LANGUAGE]
+            ?: TrackSelection.FOLLOW_SERVER_LANGUAGE
     }
 
     override fun getPreferredSubtitleLanguageFlow(): Flow<String> {
         return dataStore.data.map { preferences ->
-            preferences[Keys.PREFERRED_SUBTITLE_LANGUAGE] ?: ""
+            preferences[Keys.PREFERRED_SUBTITLE_LANGUAGE] ?: TrackSelection.FOLLOW_SERVER_LANGUAGE
         }
     }
 

--- a/app/src/main/java/com/makd/afinity/data/repository/livetv/JellyfinLiveTvRepository.kt
+++ b/app/src/main/java/com/makd/afinity/data/repository/livetv/JellyfinLiveTvRepository.kt
@@ -11,7 +11,6 @@ import com.makd.afinity.data.repository.JellyfinApiInvoker
 import com.makd.afinity.data.repository.userdata.UserDataRepository
 import com.makd.afinity.di.NetworkModule
 import com.makd.afinity.util.MediaCapabilities
-import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.jellyfin.sdk.Jellyfin
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.operations.LiveTvApi
@@ -26,7 +25,9 @@ import org.jellyfin.sdk.model.api.EncodingContext
 import org.jellyfin.sdk.model.api.ImageType
 import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.api.ItemSortBy
+import org.jellyfin.sdk.model.api.MediaProtocol
 import org.jellyfin.sdk.model.api.MediaStreamProtocol
+import org.jellyfin.sdk.model.api.OpenLiveStreamDto
 import org.jellyfin.sdk.model.api.PlayMethod
 import org.jellyfin.sdk.model.api.PlaybackInfoDto
 import org.jellyfin.sdk.model.api.SortOrder
@@ -50,6 +51,11 @@ constructor(
     private val jellyfin: Jellyfin,
 ) : LiveTvRepository {
 
+    private companion object {
+        val MPEGTS_VIDEO_CODECS = listOf("h264", "hevc", "mpeg2video", "mpeg4")
+        val MPEGTS_AUDIO_CODECS = listOf("aac", "ac3", "eac3", "mp3", "mp2")
+    }
+
     private fun getBaseUrl(): String = sessionManager.getCurrentApiClient()?.baseUrl ?: ""
 
     private suspend fun <T> apiCall(
@@ -61,6 +67,15 @@ constructor(
     private fun buildLiveTvDeviceProfile(maxBitrate: Int): DeviceProfile {
         val nativeVideoCodecs = MediaCapabilities.getSupportedVideoCodecs()
         val nativeAudioCodecs = MediaCapabilities.getSupportedAudioCodecs()
+
+        val nativeVideo = nativeVideoCodecs.split(",")
+        val nativeAudio = nativeAudioCodecs.split(",")
+        val hlsVideoCodecs =
+            MPEGTS_VIDEO_CODECS.filter { it in nativeVideo }.joinToString(",").ifEmpty { "h264" }
+        val hlsAudioCodecs =
+            MPEGTS_AUDIO_CODECS.filter { it == "mp2" || it in nativeAudio }
+                .joinToString(",")
+                .ifEmpty { "aac" }
 
         return DeviceProfile(
             name = "AFinity-LiveTV",
@@ -82,8 +97,8 @@ constructor(
                         context = EncodingContext.STREAMING,
                         protocol = MediaStreamProtocol.HLS,
                         container = "ts",
-                        videoCodec = "h264",
-                        audioCodec = "aac",
+                        videoCodec = hlsVideoCodecs,
+                        audioCodec = hlsAudioCodecs,
                         breakOnNonKeyFrames = false,
                         conditions = emptyList(),
                     )
@@ -231,7 +246,10 @@ constructor(
                 ?.map { programDto -> programDto.toAfinityProgram(baseUrl) } ?: emptyList()
         }
 
-    override suspend fun getChannelPlaybackInfo(channelId: UUID): LiveTvPlaybackInfo? =
+    override suspend fun getChannelPlaybackInfo(
+        channelId: UUID,
+        forceDirectPlay: Boolean,
+    ): LiveTvPlaybackInfo? =
         apiCall(null, "Failed to get stream URL for channel: $channelId") { apiClient, userId ->
             val baseUrl = getBaseUrl()
             if (baseUrl.isBlank()) {
@@ -243,6 +261,7 @@ constructor(
             val mediaInfoApi = MediaInfoApi(untimedClient)
             val videosApi = VideosApi(apiClient)
             val maxStreamingBitrate = 140_000_000
+            val deviceProfile = buildLiveTvDeviceProfile(maxStreamingBitrate)
 
             val playbackInfoDto =
                 PlaybackInfoDto(
@@ -250,11 +269,11 @@ constructor(
                     maxStreamingBitrate = maxStreamingBitrate,
                     enableDirectPlay = true,
                     enableDirectStream = true,
-                    enableTranscoding = false,
+                    enableTranscoding = true,
                     allowVideoStreamCopy = true,
                     allowAudioStreamCopy = true,
                     autoOpenLiveStream = false,
-                    deviceProfile = buildLiveTvDeviceProfile(maxStreamingBitrate),
+                    deviceProfile = deviceProfile,
                 )
 
             val playbackResponse =
@@ -284,12 +303,18 @@ constructor(
                             Timber.d("Opening live stream for channel $channelId")
                             MediaInfoApi(untimedClient)
                                 .openLiveStream(
-                                    openToken = token,
-                                    userId = userId,
-                                    playSessionId = playbackInfo.playSessionId,
-                                    maxStreamingBitrate = maxStreamingBitrate,
-                                    enableDirectPlay = true,
-                                    enableDirectStream = true,
+                                    data =
+                                        OpenLiveStreamDto(
+                                            openToken = token,
+                                            userId = userId,
+                                            playSessionId = playbackInfo.playSessionId,
+                                            maxStreamingBitrate = maxStreamingBitrate,
+                                            itemId = channelId,
+                                            enableDirectPlay = true,
+                                            enableDirectStream = true,
+                                            deviceProfile = deviceProfile,
+                                            directPlayProtocols = listOf(MediaProtocol.HTTP),
+                                        )
                                 )
                                 .content
                                 .mediaSource
@@ -311,21 +336,16 @@ constructor(
 
             val playMethod: PlayMethod
             val streamUrl: String
-            val container: String = source.container ?: "ts"
-
-            val isClientRemote = !isPrivateHost(baseUrl)
-
-            val isStreamLocalIp = isPrivateHost(directStreamPath)
-
-            val mustProxyStream = isClientRemote && isStreamLocalIp
+            var container: String = source.container ?: "ts"
 
             when {
-                source.supportsDirectPlay -> {
+                source.supportsDirectPlay || forceDirectPlay -> {
+                    if (!source.supportsDirectPlay) {
+                        Timber.d("Server did not offer direct play, forcing it for $channelId")
+                    }
                     playMethod = PlayMethod.DIRECT_PLAY
                     streamUrl =
-                        if (
-                            source.isRemote && !directStreamPath.isNullOrBlank() && !mustProxyStream
-                        ) {
+                        if (source.isRemote && !directStreamPath.isNullOrBlank()) {
                             directStreamPath
                         } else {
                             videosApi.getVideoStreamUrl(
@@ -341,30 +361,19 @@ constructor(
                 }
                 source.supportsDirectStream && !source.transcodingUrl.isNullOrBlank() -> {
                     playMethod = PlayMethod.DIRECT_STREAM
-                    streamUrl = source.transcodingUrl!!.toAbsoluteUrl(baseUrl)
+                    container = source.transcodingContainer ?: container
+                    streamUrl =
+                        apiClient.createUrl(source.transcodingUrl!!, ignorePathParameters = true)
+                }
+                source.supportsTranscoding && !source.transcodingUrl.isNullOrBlank() -> {
+                    playMethod = PlayMethod.TRANSCODE
+                    container = source.transcodingContainer ?: container
+                    streamUrl =
+                        apiClient.createUrl(source.transcodingUrl!!, ignorePathParameters = true)
                 }
                 else -> {
-                    Timber.w("Jellyfin wanted to transcode. FORCING Direct Play anyway.")
-                    playMethod = PlayMethod.DIRECT_PLAY
-
-                    if (
-                        !directStreamPath.isNullOrBlank() &&
-                            directStreamPath.startsWith("http") &&
-                            !mustProxyStream
-                    ) {
-                        streamUrl = directStreamPath
-                    } else {
-                        streamUrl =
-                            videosApi.getVideoStreamUrl(
-                                itemId = channelId,
-                                container = container,
-                                static = true,
-                                tag = source.eTag,
-                                mediaSourceId = mediaSourceId,
-                                liveStreamId = liveStreamId,
-                                playSessionId = playSessionId,
-                            )
-                    }
+                    Timber.e("No playable stream for channel $channelId")
+                    return@apiCall null
                 }
             }
 
@@ -378,9 +387,6 @@ constructor(
                 container = container,
             )
         }
-
-    private fun String.toAbsoluteUrl(baseUrl: String): String =
-        if (startsWith("http", ignoreCase = true)) this else "$baseUrl$this"
 
     private fun untimedApiClient(source: ApiClient): ApiClient =
         try {
@@ -397,23 +403,6 @@ constructor(
             Timber.w(e, "Failed to build untimed Live TV client, falling back to session client")
             source
         }
-
-    private fun isPrivateHost(url: String?): Boolean {
-        val host = url?.toHttpUrlOrNull()?.host ?: return false
-        if (host.equals("localhost", ignoreCase = true)) return true
-        val octets = host.split(".")
-        if (octets.size != 4) return false
-        val values = octets.map { it.toIntOrNull() ?: return false }
-        if (values.any { it !in 0..255 }) return false
-        return when {
-            values[0] == 10 -> true
-            values[0] == 127 -> true
-            values[0] == 192 && values[1] == 168 -> true
-            values[0] == 172 && values[1] in 16..31 -> true
-            values[0] == 169 && values[1] == 254 -> true
-            else -> false
-        }
-    }
 
     override suspend fun getChannelStreamUrl(channelId: UUID): String? =
         getChannelPlaybackInfo(channelId)?.streamUrl

--- a/app/src/main/java/com/makd/afinity/data/repository/livetv/LiveTvRepository.kt
+++ b/app/src/main/java/com/makd/afinity/data/repository/livetv/LiveTvRepository.kt
@@ -44,7 +44,10 @@ interface LiveTvRepository {
         limit: Int = 20,
     ): List<AfinityProgram>
 
-    suspend fun getChannelPlaybackInfo(channelId: UUID): LiveTvPlaybackInfo?
+    suspend fun getChannelPlaybackInfo(
+        channelId: UUID,
+        forceDirectPlay: Boolean = true,
+    ): LiveTvPlaybackInfo?
 
     suspend fun getChannelStreamUrl(channelId: UUID): String?
 

--- a/app/src/main/java/com/makd/afinity/data/repository/media/JellyfinMediaRepository.kt
+++ b/app/src/main/java/com/makd/afinity/data/repository/media/JellyfinMediaRepository.kt
@@ -1033,6 +1033,28 @@ constructor(
                 .distinctBy { it.id }
         }
 
+    override suspend fun getSeriesEpisodes(
+        seriesId: UUID,
+        fields: List<ItemFields>?,
+        limit: Int?,
+    ): List<AfinityEpisode> =
+        apiCall(emptyList(), "Failed to get series episodes") { apiClient, userId ->
+            TvShowsApi(apiClient)
+                .getEpisodes(
+                    seriesId = seriesId,
+                    userId = userId,
+                    isMissing = null,
+                    fields = fields ?: FieldSets.EPISODE_LIST,
+                    enableImages = true,
+                    enableUserData = true,
+                    limit = limit,
+                )
+                .content
+                .items
+                .mapNotNull { baseItem -> baseItem.toAfinityEpisode(getBaseUrl()) }
+                .distinctBy { it.id }
+        }
+
     override suspend fun getFavoriteMovies(fields: List<ItemFields>?): List<AfinityMovie> =
         apiCall(emptyList(), "Failed to get favorite movies") { apiClient, userId ->
             ItemsApi(apiClient)
@@ -1834,8 +1856,7 @@ constructor(
             val playableEpisodes = episodes.filter { !it.missing }
             if (playableEpisodes.isEmpty()) return null
 
-            val sortedEpisodes = playableEpisodes.sortedBy { it.indexNumber }
-            sortedEpisodes.firstOrNull { !it.played } ?: sortedEpisodes.firstOrNull()
+            playableEpisodes.firstOrNull { !it.played } ?: playableEpisodes.firstOrNull()
         } catch (e: Exception) {
             Timber.e(e, "Failed to determine episode to play for season: $seasonId")
             null

--- a/app/src/main/java/com/makd/afinity/data/repository/media/JellyfinMediaRepository.kt
+++ b/app/src/main/java/com/makd/afinity/data/repository/media/JellyfinMediaRepository.kt
@@ -1314,6 +1314,28 @@ constructor(
                 .toAfinityPersonDetail(getBaseUrl())
         }
 
+    override suspend fun getPersonWithoutRefresh(
+        personId: UUID,
+        fields: List<ItemFields>?,
+    ): AfinityPersonDetail? =
+        apiCall(null, "Failed to get stored person for ID: $personId") { apiClient, userId ->
+            ItemsApi(apiClient)
+                .getItems(
+                    userId = userId,
+                    ids = listOf(personId),
+                    fields = fields ?: FieldSets.PERSON_DETAIL,
+                    enableImages = true,
+                    enableUserData = true,
+                    imageTypeLimit = 1,
+                    enableTotalRecordCount = false,
+                    limit = 1,
+                )
+                .content
+                .items
+                .firstOrNull()
+                ?.toAfinityPersonDetail(getBaseUrl())
+        }
+
     override suspend fun getPersonItems(
         personId: UUID,
         includeItemTypes: List<String>,

--- a/app/src/main/java/com/makd/afinity/data/repository/media/MediaRepository.kt
+++ b/app/src/main/java/com/makd/afinity/data/repository/media/MediaRepository.kt
@@ -176,6 +176,12 @@ interface MediaRepository {
         limit: Int? = null,
     ): List<AfinityEpisode>
 
+    suspend fun getSeriesEpisodes(
+        seriesId: UUID,
+        fields: List<ItemFields>? = null,
+        limit: Int? = null,
+    ): List<AfinityEpisode>
+
     suspend fun getFavoriteShows(fields: List<ItemFields>? = null): List<AfinityShow>
 
     suspend fun getFavoriteMovies(fields: List<ItemFields>? = null): List<AfinityMovie>

--- a/app/src/main/java/com/makd/afinity/data/repository/media/MediaRepository.kt
+++ b/app/src/main/java/com/makd/afinity/data/repository/media/MediaRepository.kt
@@ -243,6 +243,11 @@ interface MediaRepository {
 
     suspend fun getPerson(personId: UUID): AfinityPersonDetail?
 
+    suspend fun getPersonWithoutRefresh(
+        personId: UUID,
+        fields: List<ItemFields>? = null,
+    ): AfinityPersonDetail?
+
     suspend fun getPersonItems(
         personId: UUID,
         includeItemTypes: List<String> = emptyList(),

--- a/app/src/main/java/com/makd/afinity/player/common/TrackMapping.kt
+++ b/app/src/main/java/com/makd/afinity/player/common/TrackMapping.kt
@@ -1,0 +1,39 @@
+package com.makd.afinity.player.common
+
+import com.makd.afinity.data.models.media.AfinityMediaStream
+
+object TrackMapping {
+
+    const val EXTERNAL_SUBTITLE_ID_BASE = 128
+
+    fun embeddedOrdinal(streams: List<AfinityMediaStream>, streamIndex: Int): Int? {
+        val stream = streams.firstOrNull { it.index == streamIndex } ?: return null
+        if (stream.isExternal) return null
+        return streams
+            .filter { !it.isExternal }
+            .indexOfFirst { it.index == streamIndex }
+            .takeIf { it >= 0 }
+    }
+
+    fun streamIndexAtEmbeddedOrdinal(
+        streams: List<AfinityMediaStream>,
+        embeddedOrdinal: Int,
+    ): Int? = streams.filter { !it.isExternal }.getOrNull(embeddedOrdinal)?.index
+
+    fun audioSortKey(formatId: String?): String? =
+        formatId?.toIntOrNull()?.let { "%05d".format(it) } ?: formatId
+
+    fun sideLoadedId(streamIndex: Int): String =
+        (EXTERNAL_SUBTITLE_ID_BASE + streamIndex).toString()
+
+    fun streamIndexFromSideLoadedId(formatId: String?): Int? =
+        formatId
+            ?.toIntOrNull()
+            ?.takeIf { it >= EXTERNAL_SUBTITLE_ID_BASE }
+            ?.minus(EXTERNAL_SUBTITLE_ID_BASE)
+
+    fun streamIndexFromExternalUri(uri: String?, sideLoadedUris: Map<Int, String>): Int? {
+        if (uri == null) return null
+        return sideLoadedUris.entries.firstOrNull { it.value == uri }?.key
+    }
+}

--- a/app/src/main/java/com/makd/afinity/player/common/TrackSelection.kt
+++ b/app/src/main/java/com/makd/afinity/player/common/TrackSelection.kt
@@ -85,6 +85,7 @@ object TrackSelection {
         serverDefaultAudioStreamIndex: Int? = null,
         serverDefaultSubtitleStreamIndex: Int? = null,
         playDefaultAudioTrack: Boolean = false,
+        allowExternalAudio: Boolean = false,
     ): TrackSelectionResult {
         val audioPosition =
             selectAudio(
@@ -93,6 +94,7 @@ object TrackSelection {
                 preferredLanguage = preferredAudioLanguage,
                 serverDefaultStreamIndex = serverDefaultAudioStreamIndex,
                 playDefaultAudioTrack = playDefaultAudioTrack,
+                allowExternal = allowExternalAudio,
             )
 
         val resolvedAudioLanguage =
@@ -134,54 +136,50 @@ object TrackSelection {
         preferredLanguage: String,
         serverDefaultStreamIndex: Int?,
         playDefaultAudioTrack: Boolean,
+        allowExternal: Boolean,
     ): Int? {
-        if (audioStreams.isEmpty()) return null
+        val selectable = audioStreams.withIndex().filter { allowExternal || !it.value.isExternal }
+        if (selectable.isEmpty()) return null
 
         if (requestedStreamIndex != null) {
-            audioStreams
-                .indexOfFirst { it.index == requestedStreamIndex }
-                .takeIf { it >= 0 }
+            selectable
+                .firstOrNull { it.value.index == requestedStreamIndex }
                 ?.let {
-                    return it
+                    return it.index
                 }
         }
 
         val preferred = normalizeLanguage(preferredLanguage)
         if (preferred.isNotEmpty()) {
-            audioStreams
-                .indexOfFirst { matches(it, preferred) && it.isDefault }
-                .takeIf { it >= 0 }
+            selectable
+                .filter { matches(it.value, preferred) }
+                .minByOrNull { audioRank(it.value) }
                 ?.let {
-                    return it
-                }
-            audioStreams
-                .indexOfFirst { matches(it, preferred) }
-                .takeIf { it >= 0 }
-                ?.let {
-                    return it
+                    return it.index
                 }
         }
 
         if (playDefaultAudioTrack && preferred.isEmpty()) {
-            audioStreams
-                .indexOfFirst { it.isDefault }
-                .takeIf { it >= 0 }
+            selectable
+                .firstOrNull { it.value.isDefault }
                 ?.let {
-                    return it
+                    return it.index
                 }
         }
 
         if (serverDefaultStreamIndex != null) {
-            audioStreams
-                .indexOfFirst { it.index == serverDefaultStreamIndex }
-                .takeIf { it >= 0 }
+            selectable
+                .firstOrNull { it.value.index == serverDefaultStreamIndex }
                 ?.let {
-                    return it
+                    return it.index
                 }
         }
 
-        return audioStreams.indexOfFirst { it.isDefault }.takeIf { it >= 0 }
+        return selectable.minByOrNull { audioRank(it.value) }?.index
     }
+
+    private fun audioRank(stream: AfinityMediaStream): Int =
+        (if (stream.isDefault) 0 else 2) + (if (stream.isExternal) 1 else 0)
 
     private fun selectSubtitle(
         subtitleStreams: List<AfinityMediaStream>,
@@ -215,7 +213,8 @@ object TrackSelection {
                             (it.value.isDefault || it.value.isForced) &&
                                 matches(it.value, preferred)
                         }
-                        ?: candidates.firstOrNull { it.value.isDefault || it.value.isForced }
+                        ?: candidates.firstOrNull { it.value.isDefault }
+                        ?: candidates.firstOrNull { it.value.isForced }
 
                 SubtitlePlaybackMode.ONLY_FORCED -> candidates.firstForced(preferred)
 
@@ -223,6 +222,7 @@ object TrackSelection {
                     candidates.firstFull(preferred)
                         ?: candidates.firstOrNull { matches(it.value, preferred) }
                         ?: candidates.firstOrNull { !it.value.isForced && it.value.isDefault }
+                        ?: candidates.firstOrNull { !it.value.isForced }
                         ?: candidates.firstOrNull { it.value.isDefault || it.value.isForced }
                         ?: candidates.firstOrNull()
 
@@ -260,6 +260,7 @@ object TrackSelection {
         language: String
     ): IndexedValue<AfinityMediaStream>? =
         firstOrNull { it.value.isForced && matches(it.value, language) }
+            ?: firstOrNull { it.value.isForced && it.value.isDefault }
             ?: firstOrNull { it.value.isForced }
 
     private fun codecPriority(codec: String): Int =

--- a/app/src/main/java/com/makd/afinity/player/common/TrackSelection.kt
+++ b/app/src/main/java/com/makd/afinity/player/common/TrackSelection.kt
@@ -87,6 +87,7 @@ object TrackSelection {
         serverDefaultSubtitleStreamIndex: Int? = null,
         playDefaultAudioTrack: Boolean = false,
         allowExternalAudio: Boolean = false,
+        preferHearingImpaired: Boolean = false,
     ): TrackSelectionResult {
         val audioPosition =
             selectAudio(
@@ -126,6 +127,7 @@ object TrackSelection {
                 preferredLanguage = subtitleLanguage,
                 audioIsForeign = audioIsForeign,
                 serverDefaultStreamIndex = serverDefaultSubtitleStreamIndex,
+                preferHearingImpaired = preferHearingImpaired,
             )
 
         return TrackSelectionResult(audioPosition, subtitlePosition)
@@ -189,6 +191,7 @@ object TrackSelection {
         preferredLanguage: String,
         audioIsForeign: Boolean,
         serverDefaultStreamIndex: Int?,
+        preferHearingImpaired: Boolean,
     ): Int {
         if (requestedStreamIndex != null) {
             if (requestedStreamIndex < 0) return NO_SUBTITLE
@@ -220,16 +223,16 @@ object TrackSelection {
                 SubtitlePlaybackMode.ONLY_FORCED -> candidates.firstForced(preferred)
 
                 SubtitlePlaybackMode.ALWAYS ->
-                    candidates.firstFull(preferred)
+                    candidates.firstFull(preferred, preferHearingImpaired)
                         ?: candidates.firstOrNull { matches(it.value, preferred) }
                         ?: candidates.firstOrNull { !it.value.isForced && it.value.isDefault }
-                        ?: candidates.firstOrNull { !it.value.isForced }
+                        ?: candidates.firstFull("", preferHearingImpaired)
                         ?: candidates.firstOrNull { it.value.isDefault || it.value.isForced }
                         ?: candidates.firstOrNull()
 
                 SubtitlePlaybackMode.SMART ->
                     if (audioIsForeign) {
-                        candidates.firstFull(preferred)
+                        candidates.firstFull(preferred, preferHearingImpaired)
                             ?: candidates.firstOrNull { matches(it.value, preferred) }
                             ?: candidates.firstForced(preferred)
                     } else {
@@ -252,10 +255,17 @@ object TrackSelection {
             )
 
     private fun List<IndexedValue<AfinityMediaStream>>.firstFull(
-        language: String
+        language: String,
+        preferHearingImpaired: Boolean,
     ): IndexedValue<AfinityMediaStream>? =
-        firstOrNull { !it.value.isForced && it.value.isDefault && matches(it.value, language) }
-            ?: firstOrNull { !it.value.isForced && matches(it.value, language) }
+        filter { !it.value.isForced && matches(it.value, language) }
+            .sortedWith(
+                compareByDescending<IndexedValue<AfinityMediaStream>> {
+                        it.value.isHearingImpaired == preferHearingImpaired
+                    }
+                    .thenByDescending { it.value.isDefault }
+            )
+            .firstOrNull()
 
     private fun List<IndexedValue<AfinityMediaStream>>.firstForced(
         language: String

--- a/app/src/main/java/com/makd/afinity/player/common/TrackSelection.kt
+++ b/app/src/main/java/com/makd/afinity/player/common/TrackSelection.kt
@@ -9,6 +9,7 @@ data class TrackSelectionResult(val audioPosition: Int?, val subtitlePosition: I
 object TrackSelection {
 
     const val NO_SUBTITLE = -1
+    const val FOLLOW_SERVER_LANGUAGE = "server"
 
     private val BIBLIOGRAPHIC_TO_TERMINOLOGIC =
         mapOf(

--- a/app/src/main/java/com/makd/afinity/player/common/TrackSelection.kt
+++ b/app/src/main/java/com/makd/afinity/player/common/TrackSelection.kt
@@ -1,0 +1,278 @@
+package com.makd.afinity.player.common
+
+import com.makd.afinity.data.models.media.AfinityMediaStream
+import org.jellyfin.sdk.model.api.SubtitlePlaybackMode
+import java.util.Locale
+
+data class TrackSelectionResult(val audioPosition: Int?, val subtitlePosition: Int)
+
+object TrackSelection {
+
+    const val NO_SUBTITLE = -1
+
+    private val BIBLIOGRAPHIC_TO_TERMINOLOGIC =
+        mapOf(
+            "alb" to "sqi",
+            "arm" to "hye",
+            "baq" to "eus",
+            "bur" to "mya",
+            "chi" to "zho",
+            "cze" to "ces",
+            "dut" to "nld",
+            "fre" to "fra",
+            "geo" to "kat",
+            "ger" to "deu",
+            "gre" to "ell",
+            "ice" to "isl",
+            "mac" to "mkd",
+            "mao" to "mri",
+            "may" to "msa",
+            "per" to "fas",
+            "rum" to "ron",
+            "slo" to "slk",
+            "tib" to "bod",
+            "wel" to "cym",
+        )
+
+    private val UNKNOWN_LANGUAGES = setOf("", "und", "unknown", "none", "undefined", "zxx", "mis")
+
+    private val TERMINOLOGIC_TO_BIBLIOGRAPHIC =
+        BIBLIOGRAPHIC_TO_TERMINOLOGIC.entries.associate { (bibliographic, terminologic) ->
+            terminologic to bibliographic
+        }
+
+    private val TERMINOLOGIC_TO_TWO_LETTER: Map<String, String> by lazy {
+        Locale.getISOLanguages().associateBy { twoLetter ->
+            runCatching { Locale.forLanguageTag(twoLetter).isO3Language }
+                .getOrNull()
+                ?.takeIf { it.isNotEmpty() } ?: twoLetter
+        }
+    }
+
+    fun languageAliases(code: String?): List<String> {
+        val base = code.orEmpty().trim().lowercase(Locale.ROOT)
+        val normalized = normalizeLanguage(base)
+        if (normalized.isEmpty()) return emptyList()
+        val aliases = linkedSetOf(normalized)
+        TERMINOLOGIC_TO_BIBLIOGRAPHIC[normalized]?.let { aliases.add(it) }
+        TERMINOLOGIC_TO_TWO_LETTER[normalized]?.let { aliases.add(it) }
+        if (base.isNotEmpty()) aliases.add(base)
+        return aliases.toList()
+    }
+
+    fun normalizeLanguage(code: String?): String {
+        val base =
+            code.orEmpty().trim().substringBefore('-').substringBefore('_').lowercase(Locale.ROOT)
+        if (base in UNKNOWN_LANGUAGES) return ""
+        return when (base.length) {
+            2 ->
+                runCatching { Locale.forLanguageTag(base).isO3Language }
+                    .getOrNull()
+                    ?.takeIf { it.isNotEmpty() } ?: base
+            3 -> BIBLIOGRAPHIC_TO_TERMINOLOGIC[base] ?: base
+            else -> base
+        }
+    }
+
+    fun select(
+        audioStreams: List<AfinityMediaStream>,
+        subtitleStreams: List<AfinityMediaStream>,
+        subtitleMode: SubtitlePlaybackMode,
+        preferredAudioLanguage: String,
+        preferredSubtitleLanguage: String,
+        requestedAudioStreamIndex: Int? = null,
+        requestedSubtitleStreamIndex: Int? = null,
+        serverDefaultAudioStreamIndex: Int? = null,
+        serverDefaultSubtitleStreamIndex: Int? = null,
+        playDefaultAudioTrack: Boolean = false,
+    ): TrackSelectionResult {
+        val audioPosition =
+            selectAudio(
+                audioStreams = audioStreams,
+                requestedStreamIndex = requestedAudioStreamIndex,
+                preferredLanguage = preferredAudioLanguage,
+                serverDefaultStreamIndex = serverDefaultAudioStreamIndex,
+                playDefaultAudioTrack = playDefaultAudioTrack,
+            )
+
+        val resolvedAudioLanguage =
+            audioPosition?.let { audioStreams.getOrNull(it)?.language }
+                ?: serverDefaultAudioStreamIndex?.let { index ->
+                    audioStreams.firstOrNull { it.index == index }?.language
+                }
+                ?: audioStreams.firstOrNull { it.isDefault }?.language
+                ?: audioStreams.firstOrNull()?.language
+                ?: ""
+
+        val subtitleLanguage = preferredSubtitleLanguage.ifBlank { preferredAudioLanguage }
+        val normalizedSubtitleLanguage = normalizeLanguage(subtitleLanguage)
+        val normalizedAudioLanguage = normalizeLanguage(resolvedAudioLanguage)
+
+        val audioIsForeign =
+            when {
+                normalizedSubtitleLanguage.isEmpty() -> false
+                normalizedAudioLanguage.isEmpty() -> true
+                else -> normalizedAudioLanguage != normalizedSubtitleLanguage
+            }
+
+        val subtitlePosition =
+            selectSubtitle(
+                subtitleStreams = subtitleStreams,
+                requestedStreamIndex = requestedSubtitleStreamIndex,
+                mode = subtitleMode,
+                preferredLanguage = subtitleLanguage,
+                audioIsForeign = audioIsForeign,
+                serverDefaultStreamIndex = serverDefaultSubtitleStreamIndex,
+            )
+
+        return TrackSelectionResult(audioPosition, subtitlePosition)
+    }
+
+    private fun selectAudio(
+        audioStreams: List<AfinityMediaStream>,
+        requestedStreamIndex: Int?,
+        preferredLanguage: String,
+        serverDefaultStreamIndex: Int?,
+        playDefaultAudioTrack: Boolean,
+    ): Int? {
+        if (audioStreams.isEmpty()) return null
+
+        if (requestedStreamIndex != null) {
+            audioStreams
+                .indexOfFirst { it.index == requestedStreamIndex }
+                .takeIf { it >= 0 }
+                ?.let {
+                    return it
+                }
+        }
+
+        val preferred = normalizeLanguage(preferredLanguage)
+        if (preferred.isNotEmpty()) {
+            audioStreams
+                .indexOfFirst { matches(it, preferred) && it.isDefault }
+                .takeIf { it >= 0 }
+                ?.let {
+                    return it
+                }
+            audioStreams
+                .indexOfFirst { matches(it, preferred) }
+                .takeIf { it >= 0 }
+                ?.let {
+                    return it
+                }
+        }
+
+        if (playDefaultAudioTrack && preferred.isEmpty()) {
+            audioStreams
+                .indexOfFirst { it.isDefault }
+                .takeIf { it >= 0 }
+                ?.let {
+                    return it
+                }
+        }
+
+        if (serverDefaultStreamIndex != null) {
+            audioStreams
+                .indexOfFirst { it.index == serverDefaultStreamIndex }
+                .takeIf { it >= 0 }
+                ?.let {
+                    return it
+                }
+        }
+
+        return audioStreams.indexOfFirst { it.isDefault }.takeIf { it >= 0 }
+    }
+
+    private fun selectSubtitle(
+        subtitleStreams: List<AfinityMediaStream>,
+        requestedStreamIndex: Int?,
+        mode: SubtitlePlaybackMode,
+        preferredLanguage: String,
+        audioIsForeign: Boolean,
+        serverDefaultStreamIndex: Int?,
+    ): Int {
+        if (requestedStreamIndex != null) {
+            if (requestedStreamIndex < 0) return NO_SUBTITLE
+            return subtitleStreams
+                .indexOfFirst { it.index == requestedStreamIndex }
+                .takeIf { it >= 0 } ?: NO_SUBTITLE
+        }
+
+        if (subtitleStreams.isEmpty() || mode == SubtitlePlaybackMode.NONE) return NO_SUBTITLE
+
+        val candidates = orderedCandidates(subtitleStreams)
+        val preferred = normalizeLanguage(preferredLanguage)
+
+        val chosen =
+            when (mode) {
+                SubtitlePlaybackMode.NONE -> null
+
+                SubtitlePlaybackMode.DEFAULT ->
+                    serverDefaultStreamIndex
+                        ?.takeIf { it >= 0 }
+                        ?.let { index -> candidates.firstOrNull { it.value.index == index } }
+                        ?: candidates.firstOrNull {
+                            (it.value.isDefault || it.value.isForced) &&
+                                matches(it.value, preferred)
+                        }
+                        ?: candidates.firstOrNull { it.value.isDefault || it.value.isForced }
+
+                SubtitlePlaybackMode.ONLY_FORCED -> candidates.firstForced(preferred)
+
+                SubtitlePlaybackMode.ALWAYS ->
+                    candidates.firstFull(preferred)
+                        ?: candidates.firstOrNull { matches(it.value, preferred) }
+                        ?: candidates.firstOrNull { !it.value.isForced && it.value.isDefault }
+                        ?: candidates.firstOrNull { it.value.isDefault || it.value.isForced }
+                        ?: candidates.firstOrNull()
+
+                SubtitlePlaybackMode.SMART ->
+                    if (audioIsForeign) {
+                        candidates.firstFull(preferred)
+                            ?: candidates.firstOrNull { matches(it.value, preferred) }
+                            ?: candidates.firstForced(preferred)
+                    } else {
+                        candidates.firstForced(preferred)
+                    }
+            }
+
+        return chosen?.index ?: NO_SUBTITLE
+    }
+
+    private fun orderedCandidates(
+        subtitleStreams: List<AfinityMediaStream>
+    ): List<IndexedValue<AfinityMediaStream>> =
+        subtitleStreams
+            .withIndex()
+            .sortedWith(
+                compareByDescending<IndexedValue<AfinityMediaStream>> { it.value.isExternal }
+                    .thenByDescending { codecPriority(it.value.codec) }
+                    .thenBy { it.index }
+            )
+
+    private fun List<IndexedValue<AfinityMediaStream>>.firstFull(
+        language: String
+    ): IndexedValue<AfinityMediaStream>? =
+        firstOrNull { !it.value.isForced && it.value.isDefault && matches(it.value, language) }
+            ?: firstOrNull { !it.value.isForced && matches(it.value, language) }
+
+    private fun List<IndexedValue<AfinityMediaStream>>.firstForced(
+        language: String
+    ): IndexedValue<AfinityMediaStream>? =
+        firstOrNull { it.value.isForced && matches(it.value, language) }
+            ?: firstOrNull { it.value.isForced }
+
+    private fun codecPriority(codec: String): Int =
+        when (codec.lowercase(Locale.ROOT)) {
+            "ass",
+            "ssa" -> 4
+            "srt",
+            "subrip" -> 3
+            "pgs",
+            "pgssub" -> 2
+            else -> 1
+        }
+
+    private fun matches(stream: AfinityMediaStream, normalizedLanguage: String): Boolean =
+        normalizedLanguage.isNotEmpty() && normalizeLanguage(stream.language) == normalizedLanguage
+}

--- a/app/src/main/java/com/makd/afinity/player/common/TrackSelection.kt
+++ b/app/src/main/java/com/makd/afinity/player/common/TrackSelection.kt
@@ -195,9 +195,12 @@ object TrackSelection {
     ): Int {
         if (requestedStreamIndex != null) {
             if (requestedStreamIndex < 0) return NO_SUBTITLE
-            return subtitleStreams
+            subtitleStreams
                 .indexOfFirst { it.index == requestedStreamIndex }
-                .takeIf { it >= 0 } ?: NO_SUBTITLE
+                .takeIf { it >= 0 }
+                ?.let {
+                    return it
+                }
         }
 
         if (subtitleStreams.isEmpty() || mode == SubtitlePlaybackMode.NONE) return NO_SUBTITLE

--- a/app/src/main/java/com/makd/afinity/player/mpv/MPVPlayer.kt
+++ b/app/src/main/java/com/makd/afinity/player/mpv/MPVPlayer.kt
@@ -1207,6 +1207,7 @@ class MPVPlayer(
                             (if (json.optBoolean("forced")) C.SELECTION_FLAG_FORCED else 0)
                     )
                     .setCodecs(json.optNullableString("codec"))
+                    .setCustomData(json.optNullableString("external-filename"))
                     .build()
 
             val format =

--- a/app/src/main/java/com/makd/afinity/ui/item/ItemDetailViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/item/ItemDetailViewModel.kt
@@ -1576,6 +1576,7 @@ constructor(
     private fun getNextEpisodeOffline(show: AfinityShow): AfinityEpisode? {
         val allEpisodes =
             show.seasons
+                .filter { it.indexNumber > 0 }
                 .sortedBy { it.indexNumber }
                 .flatMap { season -> season.episodes.sortedBy { it.indexNumber } }
         return allEpisodes.firstOrNull { it.playbackPositionTicks > 0 && !it.played }

--- a/app/src/main/java/com/makd/afinity/ui/person/PersonScreen.kt
+++ b/app/src/main/java/com/makd/afinity/ui/person/PersonScreen.kt
@@ -59,8 +59,29 @@ fun PersonScreen(
 
     Box(modifier = modifier.fillMaxSize()) {
         when {
-            uiState.isLoading -> {
-                FullScreenLoading()
+            uiState.person != null -> {
+                PersonDetailContent(
+                    person = uiState.person!!,
+                    movies = uiState.movies,
+                    shows = uiState.shows,
+                    onItemClick = { item ->
+                        val route =
+                            Destination.createItemDetailRoute(
+                                itemId = item.id.toString(),
+                                itemType =
+                                    when (item) {
+                                        is AfinityShow -> "Series"
+                                        is AfinitySeason -> "Season"
+                                        else -> null
+                                    },
+                                seriesId = (item as? AfinitySeason)?.seriesId?.toString(),
+                            )
+                        navController.navigate(route)
+                    },
+                    onToggleFavorite = { viewModel.toggleFavorite() },
+                    widthSizeClass = widthSizeClass,
+                    lazyListState = lazyListState,
+                )
             }
 
             uiState.error != null -> {
@@ -85,29 +106,8 @@ fun PersonScreen(
                 }
             }
 
-            uiState.person != null -> {
-                PersonDetailContent(
-                    person = uiState.person!!,
-                    movies = uiState.movies,
-                    shows = uiState.shows,
-                    onItemClick = { item ->
-                        val route =
-                            Destination.createItemDetailRoute(
-                                itemId = item.id.toString(),
-                                itemType =
-                                    when (item) {
-                                        is AfinityShow -> "Series"
-                                        is AfinitySeason -> "Season"
-                                        else -> null
-                                    },
-                                seriesId = (item as? AfinitySeason)?.seriesId?.toString(),
-                            )
-                        navController.navigate(route)
-                    },
-                    onToggleFavorite = { viewModel.toggleFavorite() },
-                    widthSizeClass = widthSizeClass,
-                    lazyListState = lazyListState,
-                )
+            else -> {
+                FullScreenLoading()
             }
         }
 

--- a/app/src/main/java/com/makd/afinity/ui/person/PersonViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/person/PersonViewModel.kt
@@ -18,6 +18,8 @@ import com.makd.afinity.data.repository.userdata.UserDataRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -120,6 +122,7 @@ constructor(
     }
 
     private fun loadPersonDetails() {
+        val personId = personId
         if (personId == null) {
             _uiState.update {
                 it.copy(
@@ -132,47 +135,70 @@ constructor(
 
         viewModelScope.launch {
             try {
-                _uiState.update { it.copy(isLoading = true, error = null) }
+                _uiState.update { it.copy(isLoading = it.person == null, error = null) }
 
-                val person = mediaRepository.getPerson(personId)
-                if (person == null) {
-                    _uiState.update {
-                        it.copy(
-                            isLoading = false,
-                            error = context.getString(R.string.error_person_not_found),
+                coroutineScope {
+                    val storedDeferred = async { mediaRepository.getPersonWithoutRefresh(personId) }
+                    val itemsDeferred = async {
+                        mediaRepository.getPersonItems(
+                            personId = personId,
+                            includeItemTypes = listOf("Movie", "Series"),
                         )
                     }
-                    return@launch
+                    val refreshedDeferred = async { mediaRepository.getPerson(personId) }
+
+                    storedDeferred.await()?.let { stored ->
+                        _uiState.update { currentState ->
+                            currentState.copy(
+                                person = currentState.person ?: stored,
+                                isLoading = false,
+                            )
+                        }
+                    }
+
+                    val personItems = itemsDeferred.await()
+                    _uiState.update { currentState ->
+                        currentState.copy(
+                            movies = personItems.filterIsInstance<AfinityMovie>(),
+                            shows = personItems.filterIsInstance<AfinityShow>(),
+                        )
+                    }
+
+                    val person = refreshedDeferred.await() ?: _uiState.value.person
+                    if (person == null) {
+                        _uiState.update {
+                            it.copy(
+                                isLoading = false,
+                                error = context.getString(R.string.error_person_not_found),
+                            )
+                        }
+                        return@coroutineScope
+                    }
+
+                    _uiState.update { it.copy(person = person, isLoading = false) }
+                    lastLoadedAt = System.currentTimeMillis()
+
+                    if (person.hasIncompleteMetadata()) {
+                        val rechecked = mediaRepository.getPersonWithoutRefresh(personId)
+                        if (rechecked != null && rechecked.isRicherThan(person)) {
+                            _uiState.update { it.copy(person = rechecked) }
+                        }
+                    }
                 }
-
-                val personItems =
-                    mediaRepository.getPersonItems(
-                        personId = personId,
-                        includeItemTypes = listOf("Movie", "Series"),
-                    )
-
-                val movies = personItems.filterIsInstance<AfinityMovie>()
-                val shows = personItems.filterIsInstance<AfinityShow>()
-
-                _uiState.update { currentState ->
-                    currentState.copy(
-                        person = person,
-                        movies = movies,
-                        shows = shows,
-                        isLoading = false,
-                    )
-                }
-                lastLoadedAt = System.currentTimeMillis()
             } catch (e: Exception) {
                 Timber.e(e, "Failed to load person details: $personId")
                 _uiState.update { currentState ->
                     currentState.copy(
                         isLoading = false,
                         error =
-                            context.getString(
-                                R.string.error_failed_load_person_fmt,
-                                e.message ?: "",
-                            ),
+                            if (currentState.person != null) {
+                                null
+                            } else {
+                                context.getString(
+                                    R.string.error_failed_load_person_fmt,
+                                    e.message ?: "",
+                                )
+                            },
                     )
                 }
             }
@@ -218,6 +244,15 @@ constructor(
         loadPersonDetails()
     }
 }
+
+private fun AfinityPersonDetail.hasIncompleteMetadata(): Boolean =
+    overview.isBlank() || images.primary == null
+
+private fun AfinityPersonDetail.isRicherThan(other: AfinityPersonDetail): Boolean =
+    overview.length > other.overview.length ||
+        (images.primary != null && other.images.primary == null) ||
+        (premiereDate != null && other.premiereDate == null) ||
+        (externalUrls?.size ?: 0) > (other.externalUrls?.size ?: 0)
 
 data class PersonUiState(
     val person: AfinityPersonDetail? = null,

--- a/app/src/main/java/com/makd/afinity/ui/player/PlayerScreenWrapper.kt
+++ b/app/src/main/java/com/makd/afinity/ui/player/PlayerScreenWrapper.kt
@@ -54,6 +54,15 @@ fun PlayerScreenWrapper(
         }
     }
 
+    val playerViewModel: PlayerViewModel = hiltViewModel()
+    LaunchedEffect(isLiveChannel) {
+        if (isLiveChannel) {
+            playerViewModel.liveStreamFailedEvent.collect {
+                viewModel.retryLiveChannelWithoutDirectPlay()
+            }
+        }
+    }
+
     val effectiveStreamUrl = if (isLiveChannel) fetchedStreamUrl else liveStreamUrl
 
     when {

--- a/app/src/main/java/com/makd/afinity/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/player/PlayerViewModel.kt
@@ -1644,6 +1644,7 @@ constructor(
                     subtitleMode = resolveSubtitlePlaybackMode(),
                     preferredAudioLanguage = resolvePreferredAudioLanguage(),
                     preferredSubtitleLanguage = resolvePreferredSubtitleLanguage(),
+                    preferHearingImpaired = preferencesRepository.getPreferSdhSubtitles(),
                     requestedAudioStreamIndex = audioStreamIndex,
                     requestedSubtitleStreamIndex = subtitleStreamIndex,
                     serverDefaultAudioStreamIndex = serverSavedAudioIndex,
@@ -2379,6 +2380,7 @@ constructor(
                     subtitleMode = resolveSubtitlePlaybackMode(),
                     preferredAudioLanguage = resolvePreferredAudioLanguage(),
                     preferredSubtitleLanguage = resolvePreferredSubtitleLanguage(),
+                    preferHearingImpaired = preferencesRepository.getPreferSdhSubtitles(),
                     requestedAudioStreamIndex = audioStreamIndex,
                 )
             val targetSubtitleStreamIndex =

--- a/app/src/main/java/com/makd/afinity/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/player/PlayerViewModel.kt
@@ -960,8 +960,11 @@ constructor(
                 is PlayerEvent.Seek -> player.seekTo(event.positionMs)
                 is PlayerEvent.SeekRelative -> {
                     showControls()
+                    val duration = player.duration
+                    val target = player.currentPosition.coerceAtLeast(0) + event.deltaMs
                     val newPos =
-                        (player.currentPosition + event.deltaMs).coerceIn(0, player.duration)
+                        if (duration > 0) target.coerceIn(0, duration)
+                        else target.coerceAtLeast(0)
                     player.seekTo(newPos)
                 }
 
@@ -1067,15 +1070,16 @@ constructor(
                 }
 
                 is PlayerEvent.OnSeekBarDragFinished -> {
-                    val finalPos = event.positionMs
-                    player.seekTo(finalPos)
+                    val seekable = _uiState.value.duration > 0
+                    val finalPos = if (seekable) event.positionMs else player.currentPosition
+                    if (seekable) player.seekTo(finalPos)
                     updateUiState {
                         it.copy(
                             isSeeking = false,
                             showTrickplayPreview = false,
                             trickplayPreviewImage = null,
                             trickplayPreviewPosition = 0L,
-                            currentPosition = finalPos,
+                            currentPosition = finalPos.coerceAtLeast(0),
                         )
                     }
                     onSeekBarPreview(0, false)
@@ -2631,6 +2635,7 @@ constructor(
 
     fun onDoubleTapSeek(isForward: Boolean, xFraction: Float) {
         if (sendMpvGestureKeypress(xFraction)) return
+        if (_uiState.value.isLiveChannel) return
 
         val delta = if (isForward) 10000L else -10000L
         handlePlayerEvent(PlayerEvent.SeekRelative(delta))

--- a/app/src/main/java/com/makd/afinity/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/player/PlayerViewModel.kt
@@ -1637,6 +1637,8 @@ constructor(
             val subtitleStreams =
                 mediaSource.mediaStreams.filter { it.type == MediaStreamType.SUBTITLE }
 
+            val isResuming = startPositionMs > 0
+
             val trackSelection =
                 TrackSelection.select(
                     audioStreams = audioStreams,
@@ -1645,8 +1647,10 @@ constructor(
                     preferredAudioLanguage = resolvePreferredAudioLanguage(),
                     preferredSubtitleLanguage = resolvePreferredSubtitleLanguage(),
                     preferHearingImpaired = preferencesRepository.getPreferSdhSubtitles(),
-                    requestedAudioStreamIndex = audioStreamIndex,
-                    requestedSubtitleStreamIndex = subtitleStreamIndex,
+                    requestedAudioStreamIndex =
+                        audioStreamIndex ?: serverSavedAudioIndex.takeIf { isResuming },
+                    requestedSubtitleStreamIndex =
+                        subtitleStreamIndex ?: serverSavedSubtitleIndex.takeIf { isResuming },
                     serverDefaultAudioStreamIndex = serverSavedAudioIndex,
                     serverDefaultSubtitleStreamIndex = serverSavedSubtitleIndex,
                     playDefaultAudioTrack = resolvePlayDefaultAudioTrack(),

--- a/app/src/main/java/com/makd/afinity/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/player/PlayerViewModel.kt
@@ -79,6 +79,7 @@ import com.makd.afinity.data.repository.media.MediaRepository
 import com.makd.afinity.data.repository.playback.PlaybackRepository
 import com.makd.afinity.data.repository.segments.SegmentsRepository
 import com.makd.afinity.player.audiobookshelf.AudiobookshelfPlayer
+import com.makd.afinity.player.common.TrackSelection
 import com.makd.afinity.player.mpv.MPVPlayer
 import com.makd.afinity.ui.player.utils.VolumeManager
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -104,6 +105,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.model.api.MediaStreamType
+import org.jellyfin.sdk.model.api.SubtitlePlaybackMode
 import timber.log.Timber
 import java.util.Locale
 import java.util.UUID
@@ -730,8 +732,10 @@ constructor(
         val ao = preferencesRepository.getMpvAudioOutput()
         val subs = preferencesRepository.getSubtitlePreferences()
         val audioLang = preferencesRepository.getPreferredAudioLanguage()
+        val subtitleLang = preferencesRepository.getPreferredSubtitleLanguage()
         val (mpvHwDec, mpvVideoOutput, mpvAudioOutput, subtitlePrefs, preferredAudioLang) =
             MpvPrefsSnapshot(hwDec.value, vo.value, ao.value, subs, audioLang)
+        val preferredSubtitleLang = subtitleLang.ifBlank { audioLang }
 
         mpvVideoOutputValue = mpvVideoOutput
 
@@ -794,9 +798,12 @@ constructor(
             add("sub-align-y" to subtitlePrefs.verticalPosition.mpvValue)
             add("sub-align-x" to subtitlePrefs.horizontalAlignment.mpvValue)
 
-            if (preferredAudioLang.isNotEmpty()) {
-                add("alang" to preferredAudioLang)
-            }
+            TrackSelection.languageAliases(preferredAudioLang)
+                .takeIf { it.isNotEmpty() }
+                ?.let { add("alang" to it.joinToString(",")) }
+            TrackSelection.languageAliases(preferredSubtitleLang)
+                .takeIf { it.isNotEmpty() }
+                ?.let { add("slang" to it.joinToString(",")) }
             add("subs-with-matching-audio" to "yes")
             add("subs-fallback" to "no")
         }
@@ -1562,7 +1569,9 @@ constructor(
             currentItem = fullItem
 
             val chapters = fullItem.chapters
-            updateUiState { it.copy(chapters = chapters, baseUrl = apiClient.baseUrl ?: it.baseUrl) }
+            updateUiState {
+                it.copy(chapters = chapters, baseUrl = apiClient.baseUrl ?: it.baseUrl)
+            }
 
             val finalMediaSourceId =
                 if (mediaSourceId.isBlank() && fullItem.sources.isNotEmpty()) {
@@ -1622,99 +1631,30 @@ constructor(
             val subtitleStreams =
                 mediaSource.mediaStreams.filter { it.type == MediaStreamType.SUBTITLE }
 
-            val preferredSubLang = preferencesRepository.getPreferredSubtitleLanguage()
-            val preferredAudioLang = preferencesRepository.getPreferredAudioLanguage()
+            val trackSelection =
+                TrackSelection.select(
+                    audioStreams = audioStreams,
+                    subtitleStreams = subtitleStreams,
+                    subtitleMode = resolveSubtitlePlaybackMode(),
+                    preferredAudioLanguage = preferencesRepository.getPreferredAudioLanguage(),
+                    preferredSubtitleLanguage =
+                        preferencesRepository.getPreferredSubtitleLanguage(),
+                    requestedAudioStreamIndex = audioStreamIndex,
+                    requestedSubtitleStreamIndex = subtitleStreamIndex,
+                    serverDefaultAudioStreamIndex = serverSavedAudioIndex,
+                    serverDefaultSubtitleStreamIndex = serverSavedSubtitleIndex,
+                    playDefaultAudioTrack = resolvePlayDefaultAudioTrack(),
+                )
 
-            fun iso3(code: String) =
-                Locale.forLanguageTag(code).isO3Language.ifEmpty { code }.lowercase()
-
-            val audioPosition =
-                if (audioStreamIndex != null) {
-                    audioStreams.indexOfFirst { it.index == audioStreamIndex }.takeIf { it >= 0 }
-                } else if (preferredAudioLang.isNotEmpty()) {
-                    val normalizedPref = iso3(preferredAudioLang)
-                    audioStreams
-                        .indexOfFirst { stream ->
-                            stream.language.equals(preferredAudioLang, ignoreCase = true) ||
-                                iso3(stream.language) == normalizedPref
-                        }
-                        .takeIf { it >= 0 }
-                } else if (serverSavedAudioIndex != null) {
-                    audioStreams
-                        .indexOfFirst { it.index == serverSavedAudioIndex }
-                        .takeIf { it >= 0 }
-                } else {
-                    null
-                }
-
-            val resolvedAudioLang =
-                audioPosition?.let { audioStreams.getOrNull(it)?.language }
-                    ?: serverSavedAudioIndex?.let { idx ->
-                        audioStreams.find { it.index == idx }?.language
-                    }
-                    ?: preferredAudioLang.ifEmpty { null }
-                    ?: audioStreams.firstOrNull()?.language
-                    ?: ""
-
-            val subtitlePosition =
-                if (subtitleStreamIndex != null) {
-                    if (subtitleStreamIndex < 0) -1
-                    else
-                        subtitleStreams
-                            .indexOfFirst { it.index == subtitleStreamIndex }
-                            .takeIf { it >= 0 } ?: -1
-                } else if (preferredSubLang.isNotEmpty()) {
-                    val normalizedPref = iso3(preferredSubLang)
-                    subtitleStreams
-                        .indexOfFirst { stream ->
-                            stream.language.equals(preferredSubLang, ignoreCase = true) ||
-                                iso3(stream.language) == normalizedPref
-                        }
-                        .takeIf { it >= 0 }
-                } else {
-                    val audioLangKnown =
-                        resolvedAudioLang.isNotEmpty() && resolvedAudioLang != "und"
-                    val normalizedAudioLang = if (audioLangKnown) iso3(resolvedAudioLang) else ""
-
-                    val forcedLangMatch =
-                        if (audioLangKnown) {
-                            subtitleStreams
-                                .indexOfFirst { stream ->
-                                    stream.isForced &&
-                                        (stream.language.equals(
-                                            resolvedAudioLang,
-                                            ignoreCase = true,
-                                        ) || iso3(stream.language) == normalizedAudioLang)
-                                }
-                                .takeIf { it >= 0 }
-                        } else {
-                            null
-                        }
-
-                    val forcedAny = subtitleStreams.indexOfFirst { it.isForced }.takeIf { it >= 0 }
-
-                    forcedLangMatch
-                        ?: if (!audioLangKnown) forcedAny
-                        else
-                            null
-                                ?: if (
-                                    serverSavedSubtitleIndex != null &&
-                                        serverSavedSubtitleIndex >= 0
-                                ) {
-                                    subtitleStreams
-                                        .indexOfFirst { it.index == serverSavedSubtitleIndex }
-                                        .takeIf { it >= 0 }
-                                } else {
-                                    null
-                                }
-                }
+            val audioPosition = trackSelection.audioPosition
+            val subtitlePosition = trackSelection.subtitlePosition
 
             pendingAudioTrackPosition = audioPosition
             pendingSubtitleTrackPosition = subtitlePosition
             val targetAudioStreamIndex = audioPosition?.let { audioStreams.getOrNull(it)?.index }
             val targetSubtitleStreamIndex =
-                if (subtitlePosition == -1) -1
-                else subtitlePosition?.let { subtitleStreams.getOrNull(it)?.index }
+                if (subtitlePosition == TrackSelection.NO_SUBTITLE) TrackSelection.NO_SUBTITLE
+                else subtitleStreams.getOrNull(subtitlePosition)?.index
 
             updateUiState {
                 it.copy(
@@ -1795,7 +1735,9 @@ constructor(
                                     MediaItem.SubtitleConfiguration.Builder(
                                             "file://${subtitleFile.absolutePath}".toUri()
                                         )
-                                        .setId((EXTERNAL_SUBTITLE_ID_BASE + subtitleIndex).toString())
+                                        .setId(
+                                            (EXTERNAL_SUBTITLE_ID_BASE + subtitleIndex).toString()
+                                        )
                                         .setLabel(language)
                                         .setMimeType(mimeType)
                                         .setLanguage(language)
@@ -1850,7 +1792,9 @@ constructor(
                                             )
 
                                     MediaItem.SubtitleConfiguration.Builder(subtitleUrl.toUri())
-                                        .setId((EXTERNAL_SUBTITLE_ID_BASE + subtitleIndex).toString())
+                                        .setId(
+                                            (EXTERNAL_SUBTITLE_ID_BASE + subtitleIndex).toString()
+                                        )
                                         .setLabel(finalLabel)
                                         .setMimeType(mimeType)
                                         .setLanguage(stream.language ?: "eng")
@@ -2084,19 +2028,22 @@ constructor(
             if (tmdbId != null) {
                 runCatching {
                     val result = mediaRepository.getMdbListRatings(tmdbId, isMovie)
-                    result.ratings.firstOrNull { it.source.equals("imdb", ignoreCase = true) }
+                    result.ratings
+                        .firstOrNull { it.source.equals("imdb", ignoreCase = true) }
                         ?.value
-                        ?.let { imdb = String.format(java.util.Locale.ROOT, "%.1f", it) }
-                    result.ratings.firstOrNull { it.source.equals("tomatoes", ignoreCase = true) }
+                        ?.let { imdb = String.format(Locale.ROOT, "%.1f", it) }
+                    result.ratings
+                        .firstOrNull { it.source.equals("tomatoes", ignoreCase = true) }
                         ?.value
                         ?.let { rt = "${it.toInt()}%" }
-                    result.ratings.firstOrNull { it.source.equals("tmdb", ignoreCase = true) }
+                    result.ratings
+                        .firstOrNull { it.source.equals("tmdb", ignoreCase = true) }
                         ?.value
-                        ?.let { tmdb = String.format(java.util.Locale.ROOT, "%.1f", it) }
+                        ?.let { tmdb = String.format(Locale.ROOT, "%.1f", it) }
                 }
             }
             if (imdb == null && community != null) {
-                imdb = String.format(java.util.Locale.ROOT, "%.1f", community)
+                imdb = String.format(Locale.ROOT, "%.1f", community)
             }
             updateUiState {
                 it.copy(
@@ -2110,8 +2057,7 @@ constructor(
         super.onVideoSizeChanged(videoSize)
         if (videoSize.width > 0 && videoSize.height > 0) {
             isVideoPortrait = videoSize.height > videoSize.width
-            val aspectRatio =
-                videoSize.width * videoSize.pixelWidthHeightRatio / videoSize.height
+            val aspectRatio = videoSize.width * videoSize.pixelWidthHeightRatio / videoSize.height
             Timber.d(
                 "Video size changed: ${videoSize.width}x${videoSize.height}, isPortrait=$isVideoPortrait"
             )
@@ -2129,23 +2075,60 @@ constructor(
 
     override fun onTracksChanged(tracks: Tracks) {
         super.onTracksChanged(tracks)
-        var consumedPending = false
-
-        pendingAudioTrackPosition?.let { pos ->
-            pendingAudioTrackPosition = null
-            switchToTrack(C.TRACK_TYPE_AUDIO, pos)
-            consumedPending = true
-        }
-
-        pendingSubtitleTrackPosition?.let { pos ->
-            pendingSubtitleTrackPosition = null
-            switchToTrack(C.TRACK_TYPE_TEXT, pos)
-            consumedPending = true
-        }
-
-        if (!consumedPending) {
+        applyPendingTrackSelections()
+        if (pendingAudioTrackPosition == null && pendingSubtitleTrackPosition == null) {
             updateCurrentTrackSelections()
         }
+    }
+
+    private fun supportedTrackGroups(trackType: @C.TrackType Int): List<Tracks.Group> =
+        player.currentTracks.groups.filter { it.type == trackType && it.isSupported }
+
+    private fun applyPendingTrackSelections() {
+        val audioPending = pendingAudioTrackPosition
+        val subtitlePending = pendingSubtitleTrackPosition
+        if (audioPending == null && subtitlePending == null) return
+
+        val audioGroup = audioPending?.let {
+            supportedTrackGroups(C.TRACK_TYPE_AUDIO).getOrNull(it)
+        }
+        val disableSubtitles = subtitlePending == TrackSelection.NO_SUBTITLE
+        val subtitleGroup =
+            subtitlePending
+                ?.takeIf { it >= 0 }
+                ?.let { supportedTrackGroups(C.TRACK_TYPE_TEXT).getOrNull(it) }
+
+        if (audioGroup == null && subtitleGroup == null && !disableSubtitles) {
+            Timber.d(
+                "Deferring track selection, tracks not ready (audio=$audioPending, subtitle=$subtitlePending)"
+            )
+            return
+        }
+
+        player.trackSelectionParameters =
+            player.trackSelectionParameters
+                .buildUpon()
+                .apply {
+                    if (audioGroup != null) {
+                        setOverrideForType(TrackSelectionOverride(audioGroup.mediaTrackGroup, 0))
+                        setTrackTypeDisabled(C.TRACK_TYPE_AUDIO, false)
+                    }
+                    if (subtitleGroup != null) {
+                        setOverrideForType(TrackSelectionOverride(subtitleGroup.mediaTrackGroup, 0))
+                        setTrackTypeDisabled(C.TRACK_TYPE_TEXT, false)
+                        setIgnoredTextSelectionFlags(0)
+                    } else if (disableSubtitles) {
+                        clearOverridesOfType(C.TRACK_TYPE_TEXT)
+                        setTrackTypeDisabled(C.TRACK_TYPE_TEXT, true)
+                        setIgnoredTextSelectionFlags(
+                            C.SELECTION_FLAG_FORCED or C.SELECTION_FLAG_DEFAULT
+                        )
+                    }
+                }
+                .build()
+
+        if (audioGroup != null) pendingAudioTrackPosition = null
+        if (subtitleGroup != null || disableSubtitles) pendingSubtitleTrackPosition = null
     }
 
     fun switchToTrack(
@@ -2153,6 +2136,9 @@ constructor(
         index: Int,
         userInitiated: Boolean = false,
     ) {
+        if (trackType == C.TRACK_TYPE_AUDIO) pendingAudioTrackPosition = null
+        if (trackType == C.TRACK_TYPE_TEXT) pendingSubtitleTrackPosition = null
+
         if (index == -1) {
             player.trackSelectionParameters =
                 player.trackSelectionParameters
@@ -2168,27 +2154,16 @@ constructor(
                     }
                     .build()
         } else {
-            val tracksGroups =
-                player.currentTracks.groups.filter { it.type == trackType && it.isSupported }
+            val group = supportedTrackGroups(trackType).getOrNull(index)
 
-            if (tracksGroups.isEmpty()) {
-                Timber.w("No supported tracks of type $trackType available to select")
+            if (group == null) {
+                Timber.w("Track index $index not available for type $trackType")
                 updateCurrentTrackSelections()
                 return
             }
 
-            val safeIndex =
-                if (index < tracksGroups.size) {
-                    index
-                } else {
-                    Timber.w(
-                        "Track index $index out of range for type $trackType (${tracksGroups.size} available), falling back to first"
-                    )
-                    0
-                }
-
-            val group = tracksGroups[safeIndex]
-            val language = group.getTrackFormat(0).language?.takeIf { it.isNotBlank() && it != "und" }
+            val language =
+                group.getTrackFormat(0).language?.takeIf { it.isNotBlank() && it != "und" }
 
             player.trackSelectionParameters =
                 player.trackSelectionParameters
@@ -2229,6 +2204,20 @@ constructor(
         }
     }
 
+    private suspend fun resolveSubtitlePlaybackMode(): SubtitlePlaybackMode {
+        val override = preferencesRepository.getSubtitleModeOverride()
+        if (override.isNotBlank()) {
+            SubtitlePlaybackMode.fromNameOrNull(override)?.let {
+                return it
+            }
+        }
+        return sessionManager.currentSession.value?.userConfiguration?.subtitleMode
+            ?: SubtitlePlaybackMode.SMART
+    }
+
+    private fun resolvePlayDefaultAudioTrack(): Boolean =
+        sessionManager.currentSession.value?.userConfiguration?.playDefaultAudioTrack == true
+
     private fun autoUpdateSubtitleForAudio(audioPosition: Int) {
         if (_uiState.value.subtitleUserSelected) return
 
@@ -2239,25 +2228,21 @@ constructor(
                 ?: return
         val audioStreams = source.mediaStreams.filter { it.type == MediaStreamType.AUDIO }
         val subtitleStreams = source.mediaStreams.filter { it.type == MediaStreamType.SUBTITLE }
+        val requestedAudioStreamIndex = audioStreams.getOrNull(audioPosition)?.index ?: return
 
-        val audioLang = audioStreams.getOrNull(audioPosition)?.language ?: return
-        val audioLangKnown = audioLang.isNotEmpty() && audioLang != "und"
-        if (!audioLangKnown) return
-
-        fun iso3(code: String) =
-            Locale.forLanguageTag(code).isO3Language.ifEmpty { code }.lowercase()
-        val normalizedAudioLang = iso3(audioLang)
-
-        val forcedSubPosition =
-            subtitleStreams
-                .indexOfFirst { stream ->
-                    stream.isForced &&
-                        (stream.language.equals(audioLang, ignoreCase = true) ||
-                            iso3(stream.language) == normalizedAudioLang)
-                }
-                .takeIf { it >= 0 }
-
-        switchToTrack(C.TRACK_TYPE_TEXT, forcedSubPosition ?: -1)
+        viewModelScope.launch {
+            val selection =
+                TrackSelection.select(
+                    audioStreams = audioStreams,
+                    subtitleStreams = subtitleStreams,
+                    subtitleMode = resolveSubtitlePlaybackMode(),
+                    preferredAudioLanguage = preferencesRepository.getPreferredAudioLanguage(),
+                    preferredSubtitleLanguage =
+                        preferencesRepository.getPreferredSubtitleLanguage(),
+                    requestedAudioStreamIndex = requestedAudioStreamIndex,
+                )
+            switchToTrack(C.TRACK_TYPE_TEXT, selection.subtitlePosition)
+        }
     }
 
     private fun updateCurrentTrackSelections() {

--- a/app/src/main/java/com/makd/afinity/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/player/PlayerViewModel.kt
@@ -81,6 +81,7 @@ import com.makd.afinity.data.repository.media.MediaRepository
 import com.makd.afinity.data.repository.playback.PlaybackRepository
 import com.makd.afinity.data.repository.segments.SegmentsRepository
 import com.makd.afinity.player.audiobookshelf.AudiobookshelfPlayer
+import com.makd.afinity.player.common.TrackMapping
 import com.makd.afinity.player.common.TrackSelection
 import com.makd.afinity.player.mpv.MPVPlayer
 import com.makd.afinity.ui.player.utils.VolumeManager
@@ -114,7 +115,6 @@ import java.util.Locale
 import java.util.UUID
 import javax.inject.Inject
 
-internal const val EXTERNAL_SUBTITLE_ID_BASE = 128
 private const val MAX_PENDING_TRACK_ATTEMPTS = 10
 
 @UnstableApi
@@ -579,7 +579,7 @@ constructor(
                 .setUsage(C.USAGE_MEDIA)
                 .build()
 
-        val preferredAudioLang = preferencesRepository.getPreferredAudioLanguage()
+        val preferredAudioLang = resolvePreferredAudioLanguage()
 
         val trackSelector = DefaultTrackSelector(context)
         trackSelector.setParameters(
@@ -726,8 +726,8 @@ constructor(
         val vo = preferencesRepository.getMpvVideoOutput()
         val ao = preferencesRepository.getMpvAudioOutput()
         val subs = preferencesRepository.getSubtitlePreferences()
-        val audioLang = preferencesRepository.getPreferredAudioLanguage()
-        val subtitleLang = preferencesRepository.getPreferredSubtitleLanguage()
+        val audioLang = resolvePreferredAudioLanguage()
+        val subtitleLang = resolvePreferredSubtitleLanguage()
         val (mpvHwDec, mpvVideoOutput, mpvAudioOutput, subtitlePrefs, preferredAudioLang) =
             MpvPrefsSnapshot(hwDec.value, vo.value, ao.value, subs, audioLang)
         val preferredSubtitleLang = subtitleLang.ifBlank { audioLang }
@@ -1642,9 +1642,8 @@ constructor(
                     audioStreams = audioStreams,
                     subtitleStreams = subtitleStreams,
                     subtitleMode = resolveSubtitlePlaybackMode(),
-                    preferredAudioLanguage = preferencesRepository.getPreferredAudioLanguage(),
-                    preferredSubtitleLanguage =
-                        preferencesRepository.getPreferredSubtitleLanguage(),
+                    preferredAudioLanguage = resolvePreferredAudioLanguage(),
+                    preferredSubtitleLanguage = resolvePreferredSubtitleLanguage(),
                     requestedAudioStreamIndex = audioStreamIndex,
                     requestedSubtitleStreamIndex = subtitleStreamIndex,
                     serverDefaultAudioStreamIndex = serverSavedAudioIndex,
@@ -1747,7 +1746,7 @@ constructor(
                                             "file://${subtitleFile.absolutePath}".toUri()
                                         )
                                         .setId(
-                                            (EXTERNAL_SUBTITLE_ID_BASE + streamIndex).toString()
+                                            TrackMapping.sideLoadedId(streamIndex)
                                         )
                                         .setLabel(language)
                                         .setMimeType(mimeType)
@@ -1818,7 +1817,7 @@ constructor(
 
                                     MediaItem.SubtitleConfiguration.Builder(subtitleUrl.toUri())
                                         .setId(
-                                            (EXTERNAL_SUBTITLE_ID_BASE + stream.index).toString()
+                                            TrackMapping.sideLoadedId(stream.index)
                                         )
                                         .setLabel(finalLabel)
                                         .setMimeType(mimeType)
@@ -1834,7 +1833,7 @@ constructor(
                     externalSubtitles
                         .mapNotNull { config ->
                             config.id?.toIntOrNull()?.let { id ->
-                                (id - EXTERNAL_SUBTITLE_ID_BASE) to config.uri.toString()
+                                (id - TrackMapping.EXTERNAL_SUBTITLE_ID_BASE) to config.uri.toString()
                             }
                         }
                         .toMap()
@@ -2131,29 +2130,19 @@ constructor(
     private fun orderedAudioGroups(): List<Tracks.Group> =
         player.currentTracks.groups
             .filter { it.type == C.TRACK_TYPE_AUDIO }
-            .sortedBy { group ->
-                val formatId = group.mediaTrackGroup.getFormat(0).id
-                formatId?.toIntOrNull()?.let { "%05d".format(it) } ?: formatId
-            }
+            .sortedBy { TrackMapping.audioSortKey(it.mediaTrackGroup.getFormat(0).id) }
 
     private fun textGroups(): List<Tracks.Group> =
         player.currentTracks.groups.filter { it.type == C.TRACK_TYPE_TEXT }
 
-    private fun embeddedOrdinalOf(streams: List<AfinityMediaStream>, streamIndex: Int): Int? {
-        val stream = streams.firstOrNull { it.index == streamIndex } ?: return null
-        if (stream.isExternal) return null
-        return streams.filter { !it.isExternal }.indexOfFirst { it.index == streamIndex }.takeIf {
-            it >= 0
-        }
-    }
-
     private fun audioGroupForStreamIndex(streamIndex: Int): Tracks.Group? {
-        val ordinal = embeddedOrdinalOf(currentMediaStreams(MediaStreamType.AUDIO), streamIndex)
+        val ordinal =
+            TrackMapping.embeddedOrdinal(currentMediaStreams(MediaStreamType.AUDIO), streamIndex)
         return ordinal?.let { orderedAudioGroups().getOrNull(it) }?.takeIf { it.isSupported }
     }
 
     private fun subtitleGroupForStreamIndex(streamIndex: Int): Tracks.Group? {
-        val sideLoadedId = (EXTERNAL_SUBTITLE_ID_BASE + streamIndex).toString()
+        val sideLoadedId = TrackMapping.sideLoadedId(streamIndex)
         val sideLoadedUri = sideLoadedSubtitleUris[streamIndex]
         val groups = textGroups()
         groups
@@ -2165,34 +2154,36 @@ constructor(
             ?.let {
                 return it.takeIf { group -> group.isSupported }
             }
-        val ordinal = embeddedOrdinalOf(currentMediaStreams(MediaStreamType.SUBTITLE), streamIndex)
+        val ordinal =
+            TrackMapping.embeddedOrdinal(currentMediaStreams(MediaStreamType.SUBTITLE), streamIndex)
         return ordinal?.let { groups.getOrNull(it) }?.takeIf { it.isSupported }
     }
 
     private fun streamIndexForAudioGroup(group: Tracks.Group): Int? {
         val ordinal = orderedAudioGroups().indexOf(group).takeIf { it >= 0 } ?: return null
-        return currentMediaStreams(MediaStreamType.AUDIO)
-            .filter { !it.isExternal }
-            .getOrNull(ordinal)
-            ?.index
+        return TrackMapping.streamIndexAtEmbeddedOrdinal(
+            currentMediaStreams(MediaStreamType.AUDIO),
+            ordinal,
+        )
     }
 
     private fun streamIndexForSubtitleGroup(group: Tracks.Group): Int? {
         val format = group.mediaTrackGroup.getFormat(0)
-        val formatId = format.id?.toIntOrNull()
-        if (formatId != null && formatId >= EXTERNAL_SUBTITLE_ID_BASE) {
-            return formatId - EXTERNAL_SUBTITLE_ID_BASE
+        TrackMapping.streamIndexFromSideLoadedId(format.id)?.let {
+            return it
         }
-        (format.customData as? String)?.let { external ->
-            sideLoadedSubtitleUris.entries.firstOrNull { it.value == external }?.let {
-                return it.key
+        TrackMapping.streamIndexFromExternalUri(
+                format.customData as? String,
+                sideLoadedSubtitleUris,
+            )
+            ?.let {
+                return it
             }
-        }
         val ordinal = textGroups().indexOf(group).takeIf { it >= 0 } ?: return null
-        return currentMediaStreams(MediaStreamType.SUBTITLE)
-            .filter { !it.isExternal }
-            .getOrNull(ordinal)
-            ?.index
+        return TrackMapping.streamIndexAtEmbeddedOrdinal(
+            currentMediaStreams(MediaStreamType.SUBTITLE),
+            ordinal,
+        )
     }
 
     private fun applyPendingTrackSelections() {
@@ -2350,6 +2341,24 @@ constructor(
     private fun resolvePlayDefaultAudioTrack(): Boolean =
         sessionManager.currentSession.value?.userConfiguration?.playDefaultAudioTrack == true
 
+    private suspend fun resolvePreferredAudioLanguage(): String {
+        val local = preferencesRepository.getPreferredAudioLanguage()
+        if (local != TrackSelection.FOLLOW_SERVER_LANGUAGE) return local
+        return sessionManager.currentSession.value
+            ?.userConfiguration
+            ?.audioLanguagePreference
+            .orEmpty()
+    }
+
+    private suspend fun resolvePreferredSubtitleLanguage(): String {
+        val local = preferencesRepository.getPreferredSubtitleLanguage()
+        if (local != TrackSelection.FOLLOW_SERVER_LANGUAGE) return local
+        return sessionManager.currentSession.value
+            ?.userConfiguration
+            ?.subtitleLanguagePreference
+            .orEmpty()
+    }
+
     private fun autoUpdateSubtitleForAudio(audioStreamIndex: Int) {
         if (_uiState.value.subtitleUserSelected) return
 
@@ -2368,9 +2377,8 @@ constructor(
                     audioStreams = audioStreams,
                     subtitleStreams = subtitleStreams,
                     subtitleMode = resolveSubtitlePlaybackMode(),
-                    preferredAudioLanguage = preferencesRepository.getPreferredAudioLanguage(),
-                    preferredSubtitleLanguage =
-                        preferencesRepository.getPreferredSubtitleLanguage(),
+                    preferredAudioLanguage = resolvePreferredAudioLanguage(),
+                    preferredSubtitleLanguage = resolvePreferredSubtitleLanguage(),
                     requestedAudioStreamIndex = audioStreamIndex,
                 )
             val targetSubtitleStreamIndex =

--- a/app/src/main/java/com/makd/afinity/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/player/PlayerViewModel.kt
@@ -56,6 +56,7 @@ import com.makd.afinity.data.models.media.AfinityChapter
 import com.makd.afinity.data.models.media.AfinityEpisode
 import com.makd.afinity.data.models.media.AfinityImages
 import com.makd.afinity.data.models.media.AfinityItem
+import com.makd.afinity.data.models.media.AfinityMediaStream
 import com.makd.afinity.data.models.media.AfinityMovie
 import com.makd.afinity.data.models.media.AfinitySegment
 import com.makd.afinity.data.models.media.AfinitySegmentType
@@ -113,7 +114,8 @@ import java.util.Locale
 import java.util.UUID
 import javax.inject.Inject
 
-private const val EXTERNAL_SUBTITLE_ID_BASE = 128
+internal const val EXTERNAL_SUBTITLE_ID_BASE = 128
+private const val MAX_PENDING_TRACK_ATTEMPTS = 10
 
 @UnstableApi
 @HiltViewModel
@@ -188,8 +190,10 @@ constructor(
 
     private var progressReportingJob: Job? = null
     private var pendingMainItemOptions: MainItemPlaybackOptions? = null
-    private var pendingAudioTrackPosition: Int? = null
-    private var pendingSubtitleTrackPosition: Int? = null
+    private var pendingAudioStreamIndex: Int? = null
+    private var pendingSubtitleStreamIndex: Int? = null
+    private var sideLoadedSubtitleUris: Map<Int, String> = emptyMap()
+    private var pendingTrackResolveAttempts = 0
     private var currentItem: AfinityItem? = null
     val currentPlayingItemId: UUID?
         get() = currentItem?.id
@@ -271,13 +275,8 @@ constructor(
         val source = item.sources.firstOrNull { it.id == sourceId } ?: return
         if (source.type == AfinitySourceType.LOCAL) return
 
-        val audioStreams = source.mediaStreams.filter { it.type == MediaStreamType.AUDIO }
-        val subStreams = source.mediaStreams.filter { it.type == MediaStreamType.SUBTITLE }
-        val jfAudioIndex = state.audioStreamIndex?.let { audioStreams.getOrNull(it)?.index }
-        val jfSubIndex =
-            state.subtitleStreamIndex?.let {
-                if (it < 0) -1 else subStreams.getOrNull(it)?.index
-            }
+        val jfAudioIndex = state.audioStreamIndex
+        val jfSubIndex = state.subtitleStreamIndex
 
         val position = player.currentPosition
         Timber.d("Server URL changed mid-playback, migrating stream at ${position}ms")
@@ -524,19 +523,10 @@ constructor(
                             val source =
                                 item.sources.firstOrNull { it.id == sourceId }
                                     ?: item.sources.firstOrNull()
-                            val audioStreams =
-                                source?.mediaStreams?.filter { it.type == MediaStreamType.AUDIO }
-                            val subStreams =
-                                source?.mediaStreams?.filter { it.type == MediaStreamType.SUBTITLE }
-
-                            val jfAudioIndex =
-                                _uiState.value.audioStreamIndex?.let {
-                                    audioStreams?.getOrNull(it)?.index
-                                }
+                            val jfAudioIndex = _uiState.value.audioStreamIndex
                             val jfSubIndex =
-                                _uiState.value.subtitleStreamIndex?.let {
-                                    subStreams?.getOrNull(it)?.index
-                                } ?: -1
+                                _uiState.value.subtitleStreamIndex
+                                    ?: TrackSelection.NO_SUBTITLE
 
                             val livePlaybackInfo = currentLivePlaybackInfo
                             playbackRepository.reportPlaybackProgress(
@@ -1665,18 +1655,20 @@ constructor(
             val audioPosition = trackSelection.audioPosition
             val subtitlePosition = trackSelection.subtitlePosition
 
-            pendingAudioTrackPosition = audioPosition
-            pendingSubtitleTrackPosition = subtitlePosition
             val targetAudioStreamIndex = audioPosition?.let { audioStreams.getOrNull(it)?.index }
             val targetSubtitleStreamIndex =
                 if (subtitlePosition == TrackSelection.NO_SUBTITLE) TrackSelection.NO_SUBTITLE
                 else subtitleStreams.getOrNull(subtitlePosition)?.index
 
+            pendingAudioStreamIndex = targetAudioStreamIndex
+            pendingSubtitleStreamIndex = targetSubtitleStreamIndex
+            pendingTrackResolveAttempts = 0
+
             updateUiState {
                 it.copy(
                     currentItem = fullItem,
-                    audioStreamIndex = audioPosition,
-                    subtitleStreamIndex = subtitlePosition,
+                    audioStreamIndex = targetAudioStreamIndex,
+                    subtitleStreamIndex = targetSubtitleStreamIndex,
                     subtitleUserSelected = false,
                     availableSources = fullItem.sources,
                     currentMediaSourceId = actualMediaSourceId,
@@ -1742,8 +1734,11 @@ constructor(
                                         subtitleMimeType(subtitleFile.extension)
                                             ?: MimeTypes.TEXT_UNKNOWN
 
-                                    val rawCode =
-                                        subtitleFile.nameWithoutExtension.split("_").firstOrNull()
+                                    val nameParts =
+                                        subtitleFile.nameWithoutExtension.split("_")
+                                    val streamIndex =
+                                        nameParts.getOrNull(1)?.toIntOrNull() ?: subtitleIndex
+                                    val rawCode = nameParts.firstOrNull()
                                     val language =
                                         rawCode.toLocalizedLanguageName()
                                             ?: context.getString(R.string.track_unknown)
@@ -1752,7 +1747,7 @@ constructor(
                                             "file://${subtitleFile.absolutePath}".toUri()
                                         )
                                         .setId(
-                                            (EXTERNAL_SUBTITLE_ID_BASE + subtitleIndex).toString()
+                                            (EXTERNAL_SUBTITLE_ID_BASE + streamIndex).toString()
                                         )
                                         .setLabel(language)
                                         .setMimeType(mimeType)
@@ -1766,18 +1761,32 @@ constructor(
                             emptyList()
                         }
                     } else {
+                        val negotiatedDeliveryUrls =
+                            negotiatedSource
+                                ?.mediaStreams
+                                .orEmpty()
+                                .mapNotNull { stream ->
+                                    stream.deliveryUrl?.takeIf { it.isNotBlank() }?.let {
+                                        stream.index to it
+                                    }
+                                }
+                                .toMap()
+
                         mediaSource.mediaStreams
                             .filter { stream ->
                                 stream.type == MediaStreamType.SUBTITLE && stream.isExternal
                             }
-                            .mapIndexedNotNull { subtitleIndex, stream ->
+                            .mapNotNull { stream ->
                                 try {
                                     val extension = subtitleExtension(stream.codec)
                                     val mimeType =
                                         subtitleMimeType(stream.codec)
                                             ?: MimeTypes.APPLICATION_SUBRIP
                                     val subtitleUrl =
-                                        "${apiClient.baseUrl}/Videos/${fullItem.id}/${actualMediaSourceId}/Subtitles/${stream.index}/Stream.$extension"
+                                        negotiatedDeliveryUrls[stream.index]?.let {
+                                            "${apiClient.baseUrl}$it"
+                                        }
+                                            ?: "${apiClient.baseUrl}/Videos/${fullItem.id}/${actualMediaSourceId}/Subtitles/${stream.index}/Stream.$extension"
                                     val langCode = stream.language ?: "eng"
                                     val localizedLang = langCode.toLocalizedLanguageName()
                                     val finalLabel =
@@ -1809,7 +1818,7 @@ constructor(
 
                                     MediaItem.SubtitleConfiguration.Builder(subtitleUrl.toUri())
                                         .setId(
-                                            (EXTERNAL_SUBTITLE_ID_BASE + subtitleIndex).toString()
+                                            (EXTERNAL_SUBTITLE_ID_BASE + stream.index).toString()
                                         )
                                         .setLabel(finalLabel)
                                         .setMimeType(mimeType)
@@ -1820,6 +1829,16 @@ constructor(
                                 }
                             }
                     }
+
+                sideLoadedSubtitleUris =
+                    externalSubtitles
+                        .mapNotNull { config ->
+                            config.id?.toIntOrNull()?.let { id ->
+                                (id - EXTERNAL_SUBTITLE_ID_BASE) to config.uri.toString()
+                            }
+                        }
+                        .toMap()
+                updateUiState { it.copy(sideLoadedSubtitleUris = sideLoadedSubtitleUris) }
 
                 val mediaItem =
                     MediaItem.Builder()
@@ -2092,7 +2111,7 @@ constructor(
     override fun onTracksChanged(tracks: Tracks) {
         super.onTracksChanged(tracks)
         applyPendingTrackSelections()
-        if (pendingAudioTrackPosition == null && pendingSubtitleTrackPosition == null) {
+        if (pendingAudioStreamIndex == null && pendingSubtitleStreamIndex == null) {
             updateCurrentTrackSelections()
         }
     }
@@ -2100,24 +2119,97 @@ constructor(
     private fun supportedTrackGroups(trackType: @C.TrackType Int): List<Tracks.Group> =
         player.currentTracks.groups.filter { it.type == trackType && it.isSupported }
 
+    private fun currentMediaStreams(type: MediaStreamType): List<AfinityMediaStream> {
+        val state = _uiState.value
+        val item = state.currentItem ?: return emptyList()
+        val source =
+            item.sources.firstOrNull { it.id == state.currentMediaSourceId }
+                ?: item.sources.firstOrNull()
+        return source?.mediaStreams?.filter { it.type == type }.orEmpty()
+    }
+
+    private fun orderedAudioGroups(): List<Tracks.Group> =
+        player.currentTracks.groups
+            .filter { it.type == C.TRACK_TYPE_AUDIO }
+            .sortedBy { group ->
+                val formatId = group.mediaTrackGroup.getFormat(0).id
+                formatId?.toIntOrNull()?.let { "%05d".format(it) } ?: formatId
+            }
+
+    private fun textGroups(): List<Tracks.Group> =
+        player.currentTracks.groups.filter { it.type == C.TRACK_TYPE_TEXT }
+
+    private fun embeddedOrdinalOf(streams: List<AfinityMediaStream>, streamIndex: Int): Int? {
+        val stream = streams.firstOrNull { it.index == streamIndex } ?: return null
+        if (stream.isExternal) return null
+        return streams.filter { !it.isExternal }.indexOfFirst { it.index == streamIndex }.takeIf {
+            it >= 0
+        }
+    }
+
+    private fun audioGroupForStreamIndex(streamIndex: Int): Tracks.Group? {
+        val ordinal = embeddedOrdinalOf(currentMediaStreams(MediaStreamType.AUDIO), streamIndex)
+        return ordinal?.let { orderedAudioGroups().getOrNull(it) }?.takeIf { it.isSupported }
+    }
+
+    private fun subtitleGroupForStreamIndex(streamIndex: Int): Tracks.Group? {
+        val sideLoadedId = (EXTERNAL_SUBTITLE_ID_BASE + streamIndex).toString()
+        val sideLoadedUri = sideLoadedSubtitleUris[streamIndex]
+        val groups = textGroups()
+        groups
+            .firstOrNull { group ->
+                val format = group.mediaTrackGroup.getFormat(0)
+                format.id == sideLoadedId ||
+                    (sideLoadedUri != null && format.customData == sideLoadedUri)
+            }
+            ?.let {
+                return it.takeIf { group -> group.isSupported }
+            }
+        val ordinal = embeddedOrdinalOf(currentMediaStreams(MediaStreamType.SUBTITLE), streamIndex)
+        return ordinal?.let { groups.getOrNull(it) }?.takeIf { it.isSupported }
+    }
+
+    private fun streamIndexForAudioGroup(group: Tracks.Group): Int? {
+        val ordinal = orderedAudioGroups().indexOf(group).takeIf { it >= 0 } ?: return null
+        return currentMediaStreams(MediaStreamType.AUDIO)
+            .filter { !it.isExternal }
+            .getOrNull(ordinal)
+            ?.index
+    }
+
+    private fun streamIndexForSubtitleGroup(group: Tracks.Group): Int? {
+        val format = group.mediaTrackGroup.getFormat(0)
+        val formatId = format.id?.toIntOrNull()
+        if (formatId != null && formatId >= EXTERNAL_SUBTITLE_ID_BASE) {
+            return formatId - EXTERNAL_SUBTITLE_ID_BASE
+        }
+        (format.customData as? String)?.let { external ->
+            sideLoadedSubtitleUris.entries.firstOrNull { it.value == external }?.let {
+                return it.key
+            }
+        }
+        val ordinal = textGroups().indexOf(group).takeIf { it >= 0 } ?: return null
+        return currentMediaStreams(MediaStreamType.SUBTITLE)
+            .filter { !it.isExternal }
+            .getOrNull(ordinal)
+            ?.index
+    }
+
     private fun applyPendingTrackSelections() {
-        val audioPending = pendingAudioTrackPosition
-        val subtitlePending = pendingSubtitleTrackPosition
+        val audioPending = pendingAudioStreamIndex
+        val subtitlePending = pendingSubtitleStreamIndex
         if (audioPending == null && subtitlePending == null) return
 
-        val audioGroup = audioPending?.let {
-            supportedTrackGroups(C.TRACK_TYPE_AUDIO).getOrNull(it)
-        }
+        val audioGroup = audioPending?.let { audioGroupForStreamIndex(it) }
         val disableSubtitles = subtitlePending == TrackSelection.NO_SUBTITLE
         val subtitleGroup =
-            subtitlePending
-                ?.takeIf { it >= 0 }
-                ?.let { supportedTrackGroups(C.TRACK_TYPE_TEXT).getOrNull(it) }
+            subtitlePending?.takeIf { it >= 0 }?.let { subtitleGroupForStreamIndex(it) }
 
         if (audioGroup == null && subtitleGroup == null && !disableSubtitles) {
             Timber.d(
                 "Deferring track selection, tracks not ready (audio=$audioPending, subtitle=$subtitlePending)"
             )
+            abandonUnresolvedPendingTracks()
             return
         }
 
@@ -2143,8 +2235,27 @@ constructor(
                 }
                 .build()
 
-        if (audioGroup != null) pendingAudioTrackPosition = null
-        if (subtitleGroup != null || disableSubtitles) pendingSubtitleTrackPosition = null
+        if (audioGroup != null) pendingAudioStreamIndex = null
+        if (subtitleGroup != null || disableSubtitles) pendingSubtitleStreamIndex = null
+
+        abandonUnresolvedPendingTracks()
+    }
+
+    private fun abandonUnresolvedPendingTracks() {
+        if (pendingAudioStreamIndex == null && pendingSubtitleStreamIndex == null) {
+            pendingTrackResolveAttempts = 0
+            return
+        }
+        pendingTrackResolveAttempts++
+        if (pendingTrackResolveAttempts < MAX_PENDING_TRACK_ATTEMPTS) return
+
+        Timber.w(
+            "Giving up on track selection after $pendingTrackResolveAttempts attempts (audio=$pendingAudioStreamIndex, subtitle=$pendingSubtitleStreamIndex)"
+        )
+        pendingAudioStreamIndex = null
+        pendingSubtitleStreamIndex = null
+        pendingTrackResolveAttempts = 0
+        updateCurrentTrackSelections()
     }
 
     fun switchToTrack(
@@ -2152,8 +2263,8 @@ constructor(
         index: Int,
         userInitiated: Boolean = false,
     ) {
-        if (trackType == C.TRACK_TYPE_AUDIO) pendingAudioTrackPosition = null
-        if (trackType == C.TRACK_TYPE_TEXT) pendingSubtitleTrackPosition = null
+        if (trackType == C.TRACK_TYPE_AUDIO) pendingAudioStreamIndex = null
+        if (trackType == C.TRACK_TYPE_TEXT) pendingSubtitleStreamIndex = null
 
         if (index == -1) {
             player.trackSelectionParameters =
@@ -2170,10 +2281,15 @@ constructor(
                     }
                     .build()
         } else {
-            val group = supportedTrackGroups(trackType).getOrNull(index)
+            val group =
+                when (trackType) {
+                    C.TRACK_TYPE_AUDIO -> audioGroupForStreamIndex(index)
+                    C.TRACK_TYPE_TEXT -> subtitleGroupForStreamIndex(index)
+                    else -> supportedTrackGroups(trackType).getOrNull(index)
+                }
 
             if (group == null) {
-                Timber.w("Track index $index not available for type $trackType")
+                Timber.w("Stream index $index not available for track type $trackType")
                 updateCurrentTrackSelections()
                 return
             }
@@ -2212,10 +2328,10 @@ constructor(
                 .clearOverridesOfType(C.TRACK_TYPE_TEXT)
                 .build()
 
-        if (pendingAudioTrackPosition == null) {
+        if (pendingAudioStreamIndex == null) {
             updateUiState { it.copy(audioStreamIndex = null) }
         }
-        if (pendingSubtitleTrackPosition == null) {
+        if (pendingSubtitleStreamIndex == null) {
             updateUiState { it.copy(subtitleStreamIndex = null) }
         }
     }
@@ -2234,7 +2350,7 @@ constructor(
     private fun resolvePlayDefaultAudioTrack(): Boolean =
         sessionManager.currentSession.value?.userConfiguration?.playDefaultAudioTrack == true
 
-    private fun autoUpdateSubtitleForAudio(audioPosition: Int) {
+    private fun autoUpdateSubtitleForAudio(audioStreamIndex: Int) {
         if (_uiState.value.subtitleUserSelected) return
 
         val sourceId = _uiState.value.currentMediaSourceId ?: return
@@ -2244,7 +2360,7 @@ constructor(
                 ?: return
         val audioStreams = source.mediaStreams.filter { it.type == MediaStreamType.AUDIO }
         val subtitleStreams = source.mediaStreams.filter { it.type == MediaStreamType.SUBTITLE }
-        val requestedAudioStreamIndex = audioStreams.getOrNull(audioPosition)?.index ?: return
+        if (audioStreams.none { it.index == audioStreamIndex }) return
 
         viewModelScope.launch {
             val selection =
@@ -2255,29 +2371,32 @@ constructor(
                     preferredAudioLanguage = preferencesRepository.getPreferredAudioLanguage(),
                     preferredSubtitleLanguage =
                         preferencesRepository.getPreferredSubtitleLanguage(),
-                    requestedAudioStreamIndex = requestedAudioStreamIndex,
+                    requestedAudioStreamIndex = audioStreamIndex,
                 )
-            switchToTrack(C.TRACK_TYPE_TEXT, selection.subtitlePosition)
+            val targetSubtitleStreamIndex =
+                if (selection.subtitlePosition == TrackSelection.NO_SUBTITLE) {
+                    TrackSelection.NO_SUBTITLE
+                } else {
+                    subtitleStreams.getOrNull(selection.subtitlePosition)?.index
+                        ?: TrackSelection.NO_SUBTITLE
+                }
+            switchToTrack(C.TRACK_TYPE_TEXT, targetSubtitleStreamIndex)
         }
     }
 
     private fun updateCurrentTrackSelections() {
-        val currentAudioTrackIndex =
-            player.currentTracks.groups
-                .filter { it.type == C.TRACK_TYPE_AUDIO && it.isSupported }
-                .indexOfFirst { it.isSelected }
-                .takeIf { it != -1 }
+        val currentAudioStreamIndex =
+            orderedAudioGroups().firstOrNull { it.isSelected }?.let { streamIndexForAudioGroup(it) }
 
-        val currentSubtitleTrackIndex =
-            player.currentTracks.groups
-                .filter { it.type == C.TRACK_TYPE_TEXT && it.isSupported }
-                .indexOfFirst { it.isSelected }
-                .takeIf { it != -1 }
+        val selectedTextGroup = textGroups().firstOrNull { it.isSelected }
+        val currentSubtitleStreamIndex =
+            if (selectedTextGroup == null) TrackSelection.NO_SUBTITLE
+            else streamIndexForSubtitleGroup(selectedTextGroup)
 
         updateUiState {
             it.copy(
-                audioStreamIndex = currentAudioTrackIndex,
-                subtitleStreamIndex = currentSubtitleTrackIndex,
+                audioStreamIndex = currentAudioStreamIndex,
+                subtitleStreamIndex = currentSubtitleStreamIndex,
             )
         }
     }
@@ -2293,15 +2412,9 @@ constructor(
                     _uiState.value.currentMediaSourceId ?: item.sources.firstOrNull()?.id ?: ""
                 val source =
                     item.sources.firstOrNull { it.id == sourceId } ?: item.sources.firstOrNull()
-                val audioStreams = source?.mediaStreams?.filter { it.type == MediaStreamType.AUDIO }
-                val subStreams =
-                    source?.mediaStreams?.filter { it.type == MediaStreamType.SUBTITLE }
-
-                val jfAudioIndex =
-                    _uiState.value.audioStreamIndex?.let { audioStreams?.getOrNull(it)?.index }
+                val jfAudioIndex = _uiState.value.audioStreamIndex
                 val jfSubIndex =
-                    _uiState.value.subtitleStreamIndex?.let { subStreams?.getOrNull(it)?.index }
-                        ?: -1
+                    _uiState.value.subtitleStreamIndex ?: TrackSelection.NO_SUBTITLE
 
                 playbackRepository.reportPlaybackStart(
                     itemId = item.id,
@@ -3025,6 +3138,7 @@ constructor(
         val isSeekPreviewActive: Boolean = false,
         val seekPreviewPosition: Long = 0L,
         val playbackSpeed: Float = 1f,
+        val sideLoadedSubtitleUris: Map<Int, String> = emptyMap(),
         val audioStreamIndex: Int? = null,
         val subtitleStreamIndex: Int? = null,
         val subtitleUserSelected: Boolean = false,

--- a/app/src/main/java/com/makd/afinity/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/player/PlayerViewModel.kt
@@ -20,6 +20,7 @@ import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.MimeTypes
+import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.TrackSelectionOverride
 import androidx.media3.common.Tracks
@@ -105,6 +106,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.model.api.MediaStreamType
+import org.jellyfin.sdk.model.api.PlayMethod
 import org.jellyfin.sdk.model.api.SubtitlePlaybackMode
 import timber.log.Timber
 import java.util.Locale
@@ -159,6 +161,9 @@ constructor(
 
     private val _closePlayerEvent = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     val closePlayerEvent: SharedFlow<Unit> = _closePlayerEvent.asSharedFlow()
+
+    private val _liveStreamFailedEvent = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val liveStreamFailedEvent: SharedFlow<Unit> = _liveStreamFailedEvent.asSharedFlow()
 
     private val _uiState = MutableStateFlow(PlayerUiState())
     val uiState: StateFlow<PlayerUiState> = _uiState.asStateFlow()
@@ -830,6 +835,13 @@ constructor(
 
     override fun onPlaybackStateChanged(playbackState: Int) {
         updatePlayerState()
+    }
+
+    override fun onPlayerError(error: PlaybackException) {
+        Timber.e(error, "Player error")
+        if (currentLivePlaybackInfo?.playMethod == PlayMethod.DIRECT_PLAY.serialName) {
+            _liveStreamFailedEvent.tryEmit(Unit)
+        }
     }
 
     override fun onIsPlayingChanged(isPlaying: Boolean) {

--- a/app/src/main/java/com/makd/afinity/ui/player/PlayerWrapperViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/player/PlayerWrapperViewModel.kt
@@ -50,8 +50,23 @@ constructor(
     private val _streamError = MutableStateFlow<String?>(null)
     val streamError: StateFlow<String?> = _streamError.asStateFlow()
 
+    private var liveChannelRequest: Pair<UUID, String>? = null
+    private var liveDirectPlayFailed = false
+
+    fun retryLiveChannelWithoutDirectPlay() {
+        val (channelId, channelName) = liveChannelRequest ?: return
+        if (liveDirectPlayFailed) return
+        liveDirectPlayFailed = true
+        Timber.w("Live direct play failed for $channelId, retrying without it")
+        loadLiveChannel(channelId, channelName)
+    }
+
     fun loadLiveChannel(channelId: UUID, channelName: String) {
         viewModelScope.launch {
+            if (liveChannelRequest?.first != channelId) {
+                liveDirectPlayFailed = false
+            }
+            liveChannelRequest = channelId to channelName
             _isLoading.value = true
             _streamError.value = null
             Timber.d("PlayerWrapperViewModel: Loading live channel $channelId ($channelName)")
@@ -78,7 +93,10 @@ constructor(
                 }
 
                 val playbackInfoDeferred = viewModelScope.async {
-                    liveTvRepository.getChannelPlaybackInfo(channelId)
+                    liveTvRepository.getChannelPlaybackInfo(
+                        channelId = channelId,
+                        forceDirectPlay = !liveDirectPlayFailed,
+                    )
                 }
 
                 val channel = channelDeferred.await()

--- a/app/src/main/java/com/makd/afinity/ui/player/PlaylistManager.kt
+++ b/app/src/main/java/com/makd/afinity/ui/player/PlaylistManager.kt
@@ -89,7 +89,10 @@ class PlaylistManager @Inject constructor(private val mediaRepository: MediaRepo
         return try {
             if (seasonId != null) {
                 Timber.d("Loading episodes for season $seasonId only")
-                val episodes = mediaRepository.getEpisodes(seasonId, startingEpisode.seriesId)
+                val episodes =
+                    mediaRepository.getEpisodes(seasonId, startingEpisode.seriesId).filter {
+                        !it.missing
+                    }
 
                 if (episodes.isEmpty()) {
                     val fallbackQueue = intros.toMutableList().apply { add(startingEpisode) }
@@ -97,17 +100,17 @@ class PlaylistManager @Inject constructor(private val mediaRepository: MediaRepo
                     return true
                 }
 
-                val sortedEpisodes = episodes.sortedBy { it.indexNumber ?: 0 }.toMutableList()
-                var startIndex = sortedEpisodes.indexOfFirst { it.id == startingEpisode.id }
+                val orderedEpisodes = episodes.toMutableList()
+                var startIndex = orderedEpisodes.indexOfFirst { it.id == startingEpisode.id }
 
                 if (startIndex == -1) {
-                    sortedEpisodes.add(0, startingEpisode)
+                    orderedEpisodes.add(0, startingEpisode)
                     startIndex = 0
                 } else {
-                    sortedEpisodes[startIndex] = startingEpisode
+                    orderedEpisodes[startIndex] = startingEpisode
                 }
 
-                val finalQueue = sortedEpisodes.map { it as AfinityItem }.toMutableList()
+                val finalQueue = orderedEpisodes.map { it as AfinityItem }.toMutableList()
                 if (intros.isNotEmpty()) {
                     finalQueue.addAll(startIndex, intros)
                 }
@@ -117,41 +120,11 @@ class PlaylistManager @Inject constructor(private val mediaRepository: MediaRepo
             }
 
             Timber.d("Loading episodes for entire series")
-            val seasons = mediaRepository.getSeasons(startingEpisode.seriesId)
-
-            if (seasons.isEmpty()) {
-                val fallbackQueue = intros.toMutableList().apply { add(startingEpisode) }
-                setQueue(fallbackQueue, 0)
-                return true
-            }
-
-            val allEpisodes = mutableListOf<AfinityEpisode>()
-
-            for (season in seasons.sortedBy { it.indexNumber ?: 0 }) {
-                try {
-                    val episodes =
-                        mediaRepository.getEpisodes(season.id, startingEpisode.seriesId)
-
-                    if (episodes.isNotEmpty()) {
-                        allEpisodes.addAll(episodes.sortedBy { it.indexNumber ?: 0 })
-                    }
-
-                    if (allEpisodes.isNotEmpty()) {
-                        val tempQueue = allEpisodes.map { it as AfinityItem }.toMutableList()
-                        val currentTargetIndex =
-                            tempQueue.indexOfFirst { it.id == startingEpisode.id }
-
-                        if (currentTargetIndex != -1 && intros.isNotEmpty()) {
-                            tempQueue.addAll(currentTargetIndex, intros)
-                            setQueue(tempQueue, currentTargetIndex, contentStart = currentTargetIndex + intros.size)
-                        } else {
-                            setQueue(tempQueue, currentTargetIndex.coerceAtLeast(0))
-                        }
-                    }
-                } catch (_: Exception) {
-                    Timber.w("Failed to load episodes for season ${season.indexNumber}")
-                }
-            }
+            val allEpisodes =
+                mediaRepository
+                    .getSeriesEpisodes(startingEpisode.seriesId)
+                    .filter { !it.missing }
+                    .toMutableList()
 
             if (allEpisodes.isEmpty()) {
                 val fallbackQueue = intros.toMutableList().apply { add(startingEpisode) }

--- a/app/src/main/java/com/makd/afinity/ui/player/components/PlayerControls.kt
+++ b/app/src/main/java/com/makd/afinity/ui/player/components/PlayerControls.kt
@@ -94,6 +94,7 @@ import com.makd.afinity.data.models.syncplay.SyncPlayMemberInfo
 import com.makd.afinity.ui.components.AfinityBadge
 import com.makd.afinity.ui.components.AsyncImage
 import com.makd.afinity.ui.livetv.components.LiveBadge
+import com.makd.afinity.ui.player.EXTERNAL_SUBTITLE_ID_BASE
 import com.makd.afinity.ui.player.PlayerViewModel
 import com.makd.afinity.ui.player.toLocalizedLanguageName
 import kotlinx.coroutines.delay
@@ -152,16 +153,28 @@ fun PlayerControls(
     val unknownLang = stringResource(R.string.track_unknown)
 
     val audioStreamOptions =
-        remember(currentItem, uiState.currentMediaSourceId, unknownLang) {
+        remember(currentItem, uiState.currentMediaSourceId, player.currentTracks, unknownLang) {
             val currentSource =
                 currentItem?.sources?.firstOrNull { it.id == uiState.currentMediaSourceId }
                     ?: currentItem?.sources?.firstOrNull()
 
-            val streams =
+            val embeddedAudioStreams =
                 currentSource
                     ?.mediaStreams
-                    ?.filter { it.type == MediaStreamType.AUDIO }
-                    ?.mapIndexed { index, stream ->
+                    ?.filter { it.type == MediaStreamType.AUDIO && !it.isExternal }
+                    .orEmpty()
+
+            val streams =
+                player.currentTracks.groups
+                    .filter { it.type == C.TRACK_TYPE_AUDIO }
+                    .sortedBy { group ->
+                        val formatId = group.mediaTrackGroup.getFormat(0).id
+                        formatId?.toIntOrNull()?.let { id -> "%05d".format(id) } ?: formatId
+                    }
+                    .mapIndexedNotNull { ordinal, group ->
+                        if (!group.isSupported) return@mapIndexedNotNull null
+                        val stream = embeddedAudioStreams.getOrNull(ordinal)
+                            ?: return@mapIndexedNotNull null
                         val localizedLang =
                             if (stream.language.isNotEmpty() && stream.language != "und") {
                                 stream.language.toLocalizedLanguageName()
@@ -181,10 +194,10 @@ fun PlayerControls(
                             stream = stream,
                             displayName = displayName,
                             isDefault = stream.isDefault,
-                            position = index,
+                            position = stream.index,
                             secondaryName = trackTitle(stream, null, localizedLang),
                         )
-                    } ?: emptyList()
+                    }
             assertAudioOptions(streams)
         }
 
@@ -195,6 +208,7 @@ fun PlayerControls(
         remember(
             currentItem,
             uiState.currentMediaSourceId,
+            uiState.sideLoadedSubtitleUris,
             player.currentTracks,
             noneText,
             trackFmt,
@@ -205,6 +219,7 @@ fun PlayerControls(
             val serverSubtitleStreams =
                 currentSource?.mediaStreams?.filter { it.type == MediaStreamType.SUBTITLE }
                     ?: emptyList()
+            val embeddedSubtitleStreams = serverSubtitleStreams.filter { !it.isExternal }
 
             val options = mutableListOf<SubtitleStreamOption>()
             options.add(
@@ -216,11 +231,28 @@ fun PlayerControls(
                     isNone = true,
                 )
             )
+            var embeddedOrdinal = 0
             player.currentTracks.groups
-                .filter { it.type == C.TRACK_TYPE_TEXT && it.isSupported }
+                .filter { it.type == C.TRACK_TYPE_TEXT }
                 .forEachIndexed { index, trackGroup ->
-                    val serverStream = serverSubtitleStreams.getOrNull(index)
                     val format = trackGroup.mediaTrackGroup.getFormat(0)
+                    val sideLoadedIndex =
+                        format.id?.toIntOrNull()?.takeIf { it >= EXTERNAL_SUBTITLE_ID_BASE }?.minus(
+                            EXTERNAL_SUBTITLE_ID_BASE
+                        )
+                            ?: (format.customData as? String)?.let { external ->
+                                uiState.sideLoadedSubtitleUris.entries
+                                    .firstOrNull { it.value == external }
+                                    ?.key
+                            }
+                    val serverStream =
+                        if (sideLoadedIndex != null) {
+                            serverSubtitleStreams.firstOrNull { it.index == sideLoadedIndex }
+                        } else {
+                            embeddedSubtitleStreams.getOrNull(embeddedOrdinal++)
+                        }
+                    if (!trackGroup.isSupported) return@forEachIndexed
+                    val streamIndex = serverStream?.index ?: sideLoadedIndex ?: return@forEachIndexed
 
                     val displayName =
                         if (serverStream != null) {
@@ -253,7 +285,7 @@ fun PlayerControls(
                             stream = serverStream,
                             displayName = displayName,
                             isDefault = trackGroup.isSelected,
-                            index = index,
+                            index = streamIndex,
                             isNone = false,
                             secondaryName =
                                 subtitleSecondaryLabel(

--- a/app/src/main/java/com/makd/afinity/ui/player/components/PlayerControls.kt
+++ b/app/src/main/java/com/makd/afinity/ui/player/components/PlayerControls.kt
@@ -91,10 +91,10 @@ import com.makd.afinity.data.models.media.AfinityPerson
 import com.makd.afinity.data.models.media.AfinityShow
 import com.makd.afinity.data.models.player.PlayerEvent
 import com.makd.afinity.data.models.syncplay.SyncPlayMemberInfo
+import com.makd.afinity.player.common.TrackMapping
 import com.makd.afinity.ui.components.AfinityBadge
 import com.makd.afinity.ui.components.AsyncImage
 import com.makd.afinity.ui.livetv.components.LiveBadge
-import com.makd.afinity.ui.player.EXTERNAL_SUBTITLE_ID_BASE
 import com.makd.afinity.ui.player.PlayerViewModel
 import com.makd.afinity.ui.player.toLocalizedLanguageName
 import kotlinx.coroutines.delay
@@ -173,8 +173,8 @@ fun PlayerControls(
                     }
                     .mapIndexedNotNull { ordinal, group ->
                         if (!group.isSupported) return@mapIndexedNotNull null
-                        val stream = embeddedAudioStreams.getOrNull(ordinal)
-                            ?: return@mapIndexedNotNull null
+                        val stream =
+                            embeddedAudioStreams.getOrNull(ordinal) ?: return@mapIndexedNotNull null
                         val localizedLang =
                             if (stream.language.isNotEmpty() && stream.language != "und") {
                                 stream.language.toLocalizedLanguageName()
@@ -237,9 +237,7 @@ fun PlayerControls(
                 .forEachIndexed { index, trackGroup ->
                     val format = trackGroup.mediaTrackGroup.getFormat(0)
                     val sideLoadedIndex =
-                        format.id?.toIntOrNull()?.takeIf { it >= EXTERNAL_SUBTITLE_ID_BASE }?.minus(
-                            EXTERNAL_SUBTITLE_ID_BASE
-                        )
+                        TrackMapping.streamIndexFromSideLoadedId(format.id)
                             ?: (format.customData as? String)?.let { external ->
                                 uiState.sideLoadedSubtitleUris.entries
                                     .firstOrNull { it.value == external }
@@ -252,7 +250,8 @@ fun PlayerControls(
                             embeddedSubtitleStreams.getOrNull(embeddedOrdinal++)
                         }
                     if (!trackGroup.isSupported) return@forEachIndexed
-                    val streamIndex = serverStream?.index ?: sideLoadedIndex ?: return@forEachIndexed
+                    val streamIndex =
+                        serverStream?.index ?: sideLoadedIndex ?: return@forEachIndexed
 
                     val displayName =
                         if (serverStream != null) {
@@ -1958,7 +1957,8 @@ private fun formatAudioChannels(stream: AfinityMediaStream?): String? {
         if (base.isNotBlank()) {
             return when (base.lowercase()) {
                 "mono" -> "Mono"
-                "stereo", "downmix" -> "Stereo"
+                "stereo",
+                "downmix" -> "Stereo"
                 else -> base
             }
         }
@@ -1983,24 +1983,36 @@ private fun assertAudioOptions(options: List<AudioStreamOption>): List<AudioStre
 
 private fun prettySubtitleCodec(codec: String?): String? =
     when (val value = codec?.lowercase()) {
-        null, "" -> null
-        "subrip", "srt", "application/x-subrip" -> "SRT"
-        "ass", "ssa", "text/x-ssa", "text/x-ass" -> "ASS"
-        "webvtt", "vtt", "text/vtt" -> "VTT"
+        null,
+        "" -> null
+        "subrip",
+        "srt",
+        "application/x-subrip" -> "SRT"
+        "ass",
+        "ssa",
+        "text/x-ssa",
+        "text/x-ass" -> "ASS"
+        "webvtt",
+        "vtt",
+        "text/vtt" -> "VTT"
         "pgssub",
         "pgs",
         "hdmv_pgs_subtitle",
         "application/pgs" -> "PGS"
-        "dvdsub", "vobsub", "dvd_subtitle", "application/vobsub" -> "VOBSUB"
-        "dvbsub", "dvb_subtitle", "application/dvbsubs" -> "DVBSUB"
-        "mov_text", "tx3g", "application/x-quicktime-tx3g" -> "TX3G"
-        "application/cea-608", "application/cea-708" -> "CEA"
+        "dvdsub",
+        "vobsub",
+        "dvd_subtitle",
+        "application/vobsub" -> "VOBSUB"
+        "dvbsub",
+        "dvb_subtitle",
+        "application/dvbsubs" -> "DVBSUB"
+        "mov_text",
+        "tx3g",
+        "application/x-quicktime-tx3g" -> "TX3G"
+        "application/cea-608",
+        "application/cea-708" -> "CEA"
         else ->
-            value
-                .substringAfterLast('/')
-                .removePrefix("x-")
-                .takeIf { it.isNotBlank() }
-                ?.uppercase()
+            value.substringAfterLast('/').removePrefix("x-").takeIf { it.isNotBlank() }?.uppercase()
     }
 
 private fun subtitleFileName(path: String?): String? =
@@ -2073,14 +2085,12 @@ private fun assertSubtitleOptions(
     val duplicates =
         options.filter { !it.isNone }.groupBy { it.displayName }.filter { it.value.size > 1 }.keys
 
-    val disambiguated =
-        options.map { opt ->
-            if (opt.isNone || opt.displayName !in duplicates) return@map opt
-            if (!opt.secondaryName.isNullOrBlank()) return@map opt
-            val fallback =
-                subtitleFileName(opt.stream?.path) ?: String.format(trackFmt, opt.index + 1)
-            opt.copy(secondaryName = fallback)
-        }
+    val disambiguated = options.map { opt ->
+        if (opt.isNone || opt.displayName !in duplicates) return@map opt
+        if (!opt.secondaryName.isNullOrBlank()) return@map opt
+        val fallback = subtitleFileName(opt.stream?.path) ?: String.format(trackFmt, opt.index + 1)
+        opt.copy(secondaryName = fallback)
+    }
 
     val stillColliding =
         disambiguated
@@ -2093,8 +2103,7 @@ private fun assertSubtitleOptions(
         if (opt.isNone || (opt.displayName to opt.secondaryName) !in stillColliding) return@map opt
         val track = String.format(trackFmt, opt.index + 1)
         val secondary =
-            listOfNotNull(opt.secondaryName?.takeIf { it.isNotBlank() }, track)
-                .joinToString(" · ")
+            listOfNotNull(opt.secondaryName?.takeIf { it.isNotBlank() }, track).joinToString(" · ")
         opt.copy(secondaryName = secondary)
     }
 }

--- a/app/src/main/java/com/makd/afinity/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/settings/SettingsViewModel.kt
@@ -385,6 +385,12 @@ constructor(
         }
 
         viewModelScope.launch {
+            preferencesRepository.getSubtitleModeOverrideFlow().collect { mode ->
+                _uiState.value = _uiState.value.copy(subtitleModeOverride = mode)
+            }
+        }
+
+        viewModelScope.launch {
             preferencesRepository.getCastHevcEnabledFlow().collect {
                 _uiState.value = _uiState.value.copy(castHevcEnabled = it)
             }
@@ -715,6 +721,17 @@ constructor(
                 Timber.d("Preferred subtitle language set to: $language")
             } catch (e: Exception) {
                 Timber.e(e, "Failed to set preferred subtitle language")
+            }
+        }
+    }
+
+    fun setSubtitleModeOverride(mode: String) {
+        viewModelScope.launch {
+            try {
+                preferencesRepository.setSubtitleModeOverride(mode)
+                Timber.d("Subtitle mode override set to: $mode")
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to set subtitle mode override")
             }
         }
     }
@@ -1134,6 +1151,7 @@ data class SettingsUiState(
     val mpvHdrPeakDetection: Boolean = true,
     val preferredAudioLanguage: String = "",
     val preferredSubtitleLanguage: String = "",
+    val subtitleModeOverride: String = "",
     val castHevcEnabled: Boolean = false,
     val castMaxBitrate: Int = 16_000_000,
     val bufferSizeMb: Int = 64,

--- a/app/src/main/java/com/makd/afinity/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/settings/SettingsViewModel.kt
@@ -391,6 +391,12 @@ constructor(
         }
 
         viewModelScope.launch {
+            preferencesRepository.getPreferSdhSubtitlesFlow().collect { enabled ->
+                _uiState.value = _uiState.value.copy(preferSdhSubtitles = enabled)
+            }
+        }
+
+        viewModelScope.launch {
             preferencesRepository.getCastHevcEnabledFlow().collect {
                 _uiState.value = _uiState.value.copy(castHevcEnabled = it)
             }
@@ -721,6 +727,16 @@ constructor(
                 Timber.d("Preferred subtitle language set to: $language")
             } catch (e: Exception) {
                 Timber.e(e, "Failed to set preferred subtitle language")
+            }
+        }
+    }
+
+    fun togglePreferSdhSubtitles(enabled: Boolean) {
+        viewModelScope.launch {
+            try {
+                preferencesRepository.setPreferSdhSubtitles(enabled)
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to set SDH subtitle preference")
             }
         }
     }
@@ -1152,6 +1168,7 @@ data class SettingsUiState(
     val preferredAudioLanguage: String = "",
     val preferredSubtitleLanguage: String = "",
     val subtitleModeOverride: String = "",
+    val preferSdhSubtitles: Boolean = false,
     val castHevcEnabled: Boolean = false,
     val castMaxBitrate: Int = 16_000_000,
     val bufferSizeMb: Int = 64,

--- a/app/src/main/java/com/makd/afinity/ui/settings/player/PlayerOptionsScreen.kt
+++ b/app/src/main/java/com/makd/afinity/ui/settings/player/PlayerOptionsScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -100,6 +101,7 @@ import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.jellyfin.sdk.model.api.SubtitlePlaybackMode
 import java.io.File
 import java.util.Locale
 import kotlin.math.roundToInt
@@ -343,6 +345,15 @@ fun PlayerOptionsScreen(
                         onLanguageSelected = viewModel::setPreferredSubtitleLanguage,
                         icon = painterResource(id = R.drawable.ic_subtitles),
                     )
+
+                    SettingsDivider()
+
+                    SubtitleModeSelectorItem(
+                        icon = painterResource(id = R.drawable.ic_subtitles),
+                        title = stringResource(R.string.pref_subtitle_mode_title),
+                        selectedMode = uiState.subtitleModeOverride,
+                        onModeSelected = viewModel::setSubtitleModeOverride,
+                    )
                 }
             }
 
@@ -539,6 +550,91 @@ private fun SkipModeSelectorItem(
         }
     }
 }
+
+@Composable
+private fun SubtitleModeSelectorItem(
+    icon: Painter,
+    title: String,
+    selectedMode: String,
+    onModeSelected: (String) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val options = listOf("") + SubtitlePlaybackMode.entries.map { it.serialName }
+
+    Box {
+        SettingsItem(
+            icon = icon,
+            title = title,
+            subtitle = getSubtitleModeDisplayName(selectedMode),
+            onClick = { expanded = true },
+            trailing = {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_keyboard_arrow_down),
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(24.dp),
+                )
+            },
+        )
+
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+            modifier = Modifier.background(MaterialTheme.colorScheme.surfaceContainerHigh),
+        ) {
+            options.forEach { mode ->
+                DropdownMenuItem(
+                    text = {
+                        Column(modifier = Modifier.widthIn(max = 280.dp)) {
+                            Text(getSubtitleModeDisplayName(mode))
+                            Text(
+                                text = getSubtitleModeDescription(mode),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    },
+                    onClick = {
+                        onModeSelected(mode)
+                        expanded = false
+                    },
+                    leadingIcon =
+                        if (selectedMode == mode) {
+                            {
+                                Icon(
+                                    painter = painterResource(id = R.drawable.ic_check),
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.primary,
+                                )
+                            }
+                        } else null,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun getSubtitleModeDisplayName(mode: String): String =
+    when (SubtitlePlaybackMode.fromNameOrNull(mode)) {
+        SubtitlePlaybackMode.DEFAULT -> stringResource(R.string.subtitle_mode_default)
+        SubtitlePlaybackMode.ALWAYS -> stringResource(R.string.subtitle_mode_always)
+        SubtitlePlaybackMode.SMART -> stringResource(R.string.subtitle_mode_smart)
+        SubtitlePlaybackMode.ONLY_FORCED -> stringResource(R.string.subtitle_mode_only_forced)
+        SubtitlePlaybackMode.NONE -> stringResource(R.string.subtitle_mode_none)
+        null -> stringResource(R.string.subtitle_mode_follow_server)
+    }
+
+@Composable
+private fun getSubtitleModeDescription(mode: String): String =
+    when (SubtitlePlaybackMode.fromNameOrNull(mode)) {
+        SubtitlePlaybackMode.DEFAULT -> stringResource(R.string.subtitle_mode_default_hint)
+        SubtitlePlaybackMode.ALWAYS -> stringResource(R.string.subtitle_mode_always_hint)
+        SubtitlePlaybackMode.SMART -> stringResource(R.string.subtitle_mode_smart_hint)
+        SubtitlePlaybackMode.ONLY_FORCED -> stringResource(R.string.subtitle_mode_only_forced_hint)
+        SubtitlePlaybackMode.NONE -> stringResource(R.string.subtitle_mode_none_hint)
+        null -> stringResource(R.string.subtitle_mode_follow_server_hint)
+    }
 
 @Composable
 private fun getSkipModeDisplayName(mode: SkipMode): String =

--- a/app/src/main/java/com/makd/afinity/ui/settings/player/PlayerOptionsScreen.kt
+++ b/app/src/main/java/com/makd/afinity/ui/settings/player/PlayerOptionsScreen.kt
@@ -350,7 +350,7 @@ fun PlayerOptionsScreen(
                     SettingsDivider()
 
                     SubtitleModeSelectorItem(
-                        icon = painterResource(id = R.drawable.ic_subtitles),
+                        icon = painterResource(id = R.drawable.ic_subtitles_settings),
                         title = stringResource(R.string.pref_subtitle_mode_title),
                         selectedMode = uiState.subtitleModeOverride,
                         onModeSelected = viewModel::setSubtitleModeOverride,

--- a/app/src/main/java/com/makd/afinity/ui/settings/player/PlayerOptionsScreen.kt
+++ b/app/src/main/java/com/makd/afinity/ui/settings/player/PlayerOptionsScreen.kt
@@ -25,10 +25,11 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -558,60 +559,103 @@ private fun SubtitleModeSelectorItem(
     selectedMode: String,
     onModeSelected: (String) -> Unit,
 ) {
-    var expanded by remember { mutableStateOf(false) }
+    var showDialog by remember { mutableStateOf(false) }
+
+    SettingsItem(
+        icon = icon,
+        title = title,
+        subtitle = getSubtitleModeDisplayName(selectedMode),
+        onClick = { showDialog = true },
+        trailing = {
+            Icon(
+                painter = painterResource(id = R.drawable.ic_keyboard_arrow_down),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(24.dp),
+            )
+        },
+    )
+
+    if (showDialog) {
+        SubtitleModePickerDialog(
+            selectedMode = selectedMode,
+            onSelect = { mode ->
+                onModeSelected(mode)
+                showDialog = false
+            },
+            onDismiss = { showDialog = false },
+        )
+    }
+}
+
+@Composable
+private fun SubtitleModePickerDialog(
+    selectedMode: String,
+    onSelect: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
     val options = listOf("") + SubtitlePlaybackMode.entries.map { it.serialName }
 
-    Box {
-        SettingsItem(
-            icon = icon,
-            title = title,
-            subtitle = getSubtitleModeDisplayName(selectedMode),
-            onClick = { expanded = true },
-            trailing = {
-                Icon(
-                    painter = painterResource(id = R.drawable.ic_keyboard_arrow_down),
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.size(24.dp),
-                )
-            },
-        )
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.pref_subtitle_mode_title)) },
+        text = {
+            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                options.forEach { mode ->
+                    val isSelected = mode == selectedMode
 
-        DropdownMenu(
-            expanded = expanded,
-            onDismissRequest = { expanded = false },
-            modifier = Modifier.background(MaterialTheme.colorScheme.surfaceContainerHigh),
-        ) {
-            options.forEach { mode ->
-                DropdownMenuItem(
-                    text = {
-                        Column(modifier = Modifier.widthIn(max = 280.dp)) {
-                            Text(getSubtitleModeDisplayName(mode))
+                    Row(
+                        modifier =
+                            Modifier.fillMaxWidth()
+                                .clip(RoundedCornerShape(12.dp))
+                                .then(
+                                    if (isSelected)
+                                        Modifier.background(
+                                            MaterialTheme.colorScheme.primaryContainer.copy(
+                                                alpha = 0.3f
+                                            )
+                                        )
+                                    else Modifier
+                                )
+                                .clickable { onSelect(mode) }
+                                .padding(horizontal = 12.dp, vertical = 14.dp),
+                        verticalAlignment = Alignment.Top,
+                    ) {
+                        if (isSelected) {
+                            Icon(
+                                painter = painterResource(id = R.drawable.ic_check),
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.size(20.dp),
+                            )
+                        } else {
+                            Spacer(modifier = Modifier.size(20.dp))
+                        }
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Column {
+                            Text(
+                                text = getSubtitleModeDisplayName(mode),
+                                style = MaterialTheme.typography.bodyLarge,
+                                color =
+                                    if (isSelected) MaterialTheme.colorScheme.primary
+                                    else MaterialTheme.colorScheme.onSurface,
+                            )
+                            Spacer(modifier = Modifier.height(2.dp))
                             Text(
                                 text = getSubtitleModeDescription(mode),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
                         }
-                    },
-                    onClick = {
-                        onModeSelected(mode)
-                        expanded = false
-                    },
-                    leadingIcon =
-                        if (selectedMode == mode) {
-                            {
-                                Icon(
-                                    painter = painterResource(id = R.drawable.ic_check),
-                                    contentDescription = null,
-                                    tint = MaterialTheme.colorScheme.primary,
-                                )
-                            }
-                        } else null,
-                )
+                    }
+                }
             }
-        }
-    }
+        },
+        confirmButton = {},
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.action_cancel)) }
+        },
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/makd/afinity/ui/settings/player/PlayerOptionsScreen.kt
+++ b/app/src/main/java/com/makd/afinity/ui/settings/player/PlayerOptionsScreen.kt
@@ -355,6 +355,16 @@ fun PlayerOptionsScreen(
                         selectedMode = uiState.subtitleModeOverride,
                         onModeSelected = viewModel::setSubtitleModeOverride,
                     )
+
+                    SettingsDivider()
+
+                    SettingsSwitchItem(
+                        icon = painterResource(id = R.drawable.ic_subtitles),
+                        title = stringResource(R.string.pref_prefer_sdh_title),
+                        subtitle = stringResource(R.string.pref_prefer_sdh_summary),
+                        checked = uiState.preferSdhSubtitles,
+                        onCheckedChange = viewModel::togglePreferSdhSubtitles,
+                    )
                 }
             }
 

--- a/app/src/main/res/drawable/ic_subtitles_settings.xml
+++ b/app/src/main/res/drawable/ic_subtitles_settings.xml
@@ -1,0 +1,36 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:strokeColor="@color/white"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:pathData="M11.5,19h-5.5a3,3 0 0,1 -3,-3v-8a3,3 0 0,1 3,-3h12a3,3 0 0,1 3,3v4" />
+    <path
+        android:strokeColor="@color/white"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:pathData="M7,15h5" />
+    <path
+        android:strokeColor="@color/white"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:pathData="M17,12h-3" />
+    <path
+        android:strokeColor="@color/white"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:pathData="M11,12h-1" />
+    <path
+        android:strokeColor="@color/white"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:pathData="M19,22.5a4.75,4.75 0 0,1 3.5,-3.5a4.75,4.75 0 0,1 -3.5,-3.5a4.75,4.75 0 0,1 -3.5,3.5a4.75,4.75 0 0,1 3.5,3.5" />
+</vector>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string-array name="languages">
+        <item>@string/subtitle_mode_follow_server</item>
         <item>None</item>
         <item>Afar</item>
         <item>Abkhazian</item>
@@ -188,6 +189,7 @@
     </string-array>
 
     <string-array name="language_values">
+        <item>server</item>
         <item></item>
         <item>aar</item>
         <item>abk</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -839,9 +839,9 @@
     <string name="subtitle_mode_none">None</string>
     <string name="subtitle_mode_follow_server_hint">Use the subtitle mode configured for your account on the Jellyfin server.</string>
     <string name="subtitle_mode_default_hint">Subtitles are loaded based on the default and forced flags in the embedded metadata. Language preferences are considered when multiple options are available.</string>
-    <string name="subtitle_mode_always_hint">Subtitles matching the language preference will be loaded regardless of the audio language.</string>
-    <string name="subtitle_mode_smart_hint">Subtitles matching the language preference will be loaded when the audio is in a foreign language.</string>
-    <string name="subtitle_mode_only_forced_hint">Only subtitles marked as forced will be loaded.</string>
+    <string name="subtitle_mode_always_hint">Subtitles are loaded for every item, matching your preferred language when possible.</string>
+    <string name="subtitle_mode_smart_hint">Full subtitles are loaded when the audio isn\'t in your preferred language. Otherwise, only forced subtitles are loaded.</string>
+    <string name="subtitle_mode_only_forced_hint">Only subtitles marked as forced will be loaded — usually just on-screen text and foreign dialogue, not the full script.</string>
     <string name="subtitle_mode_none_hint">Subtitles will not be loaded by default. They can still be turned on manually during playback.</string>
     <string name="pref_autoplay_title">Auto-play</string>
     <string name="pref_autoplay_summary">Automatically play next episode</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -830,6 +830,8 @@
     <string name="pref_language_search_hint">Search languages…</string>
     <string name="pref_subtitle_mode_title">Subtitle Mode</string>
     <string name="subtitle_mode_follow_server">Follow server setting</string>
+    <string name="pref_prefer_sdh_title">Prefer SDH subtitles</string>
+    <string name="pref_prefer_sdh_summary">Auto-select hearing-impaired subtitles</string>
     <string name="subtitle_mode_default">Default</string>
     <string name="subtitle_mode_always">Always play</string>
     <string name="subtitle_mode_smart">Only for foreign audio</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -828,6 +828,19 @@
     <string name="pref_preferred_subtitle_language_title">Preferred Subtitle Language</string>
     <string name="pref_preferred_subtitle_language_summary">Auto-select subtitle track by language</string>
     <string name="pref_language_search_hint">Search languages…</string>
+    <string name="pref_subtitle_mode_title">Subtitle Mode</string>
+    <string name="subtitle_mode_follow_server">Follow server setting</string>
+    <string name="subtitle_mode_default">Default</string>
+    <string name="subtitle_mode_always">Always play</string>
+    <string name="subtitle_mode_smart">Only for foreign audio</string>
+    <string name="subtitle_mode_only_forced">Only forced subtitles</string>
+    <string name="subtitle_mode_none">None</string>
+    <string name="subtitle_mode_follow_server_hint">Use the subtitle mode configured for your account on the Jellyfin server.</string>
+    <string name="subtitle_mode_default_hint">Subtitles are loaded based on the default and forced flags in the embedded metadata. Language preferences are considered when multiple options are available.</string>
+    <string name="subtitle_mode_always_hint">Subtitles matching the language preference will be loaded regardless of the audio language.</string>
+    <string name="subtitle_mode_smart_hint">Subtitles matching the language preference will be loaded when the audio is in a foreign language.</string>
+    <string name="subtitle_mode_only_forced_hint">Only subtitles marked as forced will be loaded.</string>
+    <string name="subtitle_mode_none_hint">Subtitles will not be loaded by default. They can still be turned on manually during playback.</string>
     <string name="pref_autoplay_title">Auto-play</string>
     <string name="pref_autoplay_summary">Automatically play next episode</string>
 


### PR DESCRIPTION
## Problem

Jellyfin numbers every stream in a media source. The player only numbers the tracks it can actually see. We were treating those as the same thing, which falls apart the moment an item has external streams, because then the two lists aren't the same length.

That's where "No track selected", the wrong audio track and the wrong subtitle were all coming from. Progress reports went through the same mapping, so we were also writing nonsense back to the server and clobbering its remembered audio/subtitle indices with values that never matched anything that actually played.

## Changes

**TrackSelection** is a new pure resolver, shared by ExoPlayer and MPV. Handles all five Jellyfin subtitle modes, normalises ISO 639-2 B/T codes (so `ger`, `deu` and `de` all land on the same track), and knows the difference between forced, full and SDH subtitles.

**TrackMapping** deals with the index side. Embedded ordinals now skip external streams, audio groups get sorted by format id instead of trusting whatever order the player hands back, and side-loaded subtitles are matched by identity rather than position (`Format.id` on ExoPlayer,
`external-filename` on MPV). `uiState` carries Jellyfin stream indices everywhere now, so progress reports write the right thing.

**Settings**: subtitle mode picker, "Follow server setting" for the preferred languages (and that's the new default), a prefer-SDH toggle, and the server's `PlayDefaultAudioTrack` is actually honoured now.

There's some unrelated work on this branch as well: Live TV codec negotiation via a device profile plus seek fixes, parallel person detail loading, and a series loading optimisation.

## Behaviour

External (sidecar) audio isn't selectable any more. Jellyfin can't deliver it without a transcode, so it's excluded rather than sitting in the picker doing nothing when you tap it.

Resuming restores whatever tracks you were using. Starting something fresh applies your preferences instead.