### PR TITLE
feat: integrate Wikidata awards system and enhance metadata management

### DIFF
--- a/app/src/main/java/com/makd/afinity/data/database/AfinityDatabase.kt
+++ b/app/src/main/java/com/makd/afinity/data/database/AfinityDatabase.kt
@@ -32,6 +32,7 @@ import com.makd.afinity.data.database.dao.SourceDao
 import com.makd.afinity.data.database.dao.TopPeopleDao
 import com.makd.afinity.data.database.dao.UserDao
 import com.makd.afinity.data.database.dao.UserDataDao
+import com.makd.afinity.data.database.dao.WikidataAwardsDao
 import com.makd.afinity.data.database.entities.AbsDownloadEntity
 import com.makd.afinity.data.database.entities.AfinityEpisodeDto
 import com.makd.afinity.data.database.entities.AfinityMediaStreamDto
@@ -71,6 +72,7 @@ import com.makd.afinity.data.database.entities.MusicTrackEntity
 import com.makd.afinity.data.database.entities.PersonSectionCacheEntity
 import com.makd.afinity.data.database.entities.ShowGenreCacheEntity
 import com.makd.afinity.data.database.entities.TopPeopleCacheEntity
+import com.makd.afinity.data.database.entities.WikidataAwardsCacheEntity
 import com.makd.afinity.data.models.server.Server
 import com.makd.afinity.data.models.server.ServerAddress
 import com.makd.afinity.data.models.user.AfinityUserDataDto
@@ -122,8 +124,9 @@ import com.makd.afinity.data.models.user.User
             CustomHomeSectionEntity::class,
             HomeLayoutPreferenceEntity::class,
             DeletedItemEntity::class,
+            WikidataAwardsCacheEntity::class,
         ],
-    version = 70,
+    version = 71,
     exportSchema = false,
 )
 @TypeConverters(AfinityTypeConverters::class)
@@ -184,6 +187,8 @@ abstract class AfinityDatabase : RoomDatabase() {
     abstract fun customHomeSectionDao(): CustomHomeSectionDao
 
     abstract fun homeLayoutPreferenceDao(): HomeLayoutPreferenceDao
+
+    abstract fun wikidataAwardsDao(): WikidataAwardsDao
 
     abstract fun deletedItemDao(): DeletedItemDao
 }

--- a/app/src/main/java/com/makd/afinity/data/database/AfinityTypeConverters.kt
+++ b/app/src/main/java/com/makd/afinity/data/database/AfinityTypeConverters.kt
@@ -15,6 +15,7 @@ import com.makd.afinity.data.models.media.AfinityShow
 import com.makd.afinity.data.models.media.AfinitySourceType
 import com.makd.afinity.data.models.media.AfinityStudio
 import com.makd.afinity.data.models.tmdb.TmdbReview
+import com.makd.afinity.data.models.wikidata.WikidataAward
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import org.jellyfin.sdk.model.api.MediaStreamType
@@ -491,6 +492,20 @@ class AfinityTypeConverters {
     fun toMdbRatingBadges(badgesString: String?): MdbListRatingBadges? = badgesString?.let {
         try {
             json.decodeFromString<MdbListRatingBadges>(it)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    @TypeConverter
+    fun fromWikidataAwardList(awards: List<WikidataAward>?): String? = awards?.let {
+        json.encodeToString(it)
+    }
+
+    @TypeConverter
+    fun toWikidataAwardList(awardsString: String?): List<WikidataAward>? = awardsString?.let {
+        try {
+            json.decodeFromString<List<WikidataAward>>(it)
         } catch (e: Exception) {
             null
         }

--- a/app/src/main/java/com/makd/afinity/data/database/DatabaseMigrations.kt
+++ b/app/src/main/java/com/makd/afinity/data/database/DatabaseMigrations.kt
@@ -1486,6 +1486,21 @@ object DatabaseMigrations {
             }
         }
 
+    val MIGRATION_70_71 =
+        object : Migration(70, 71) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `wikidata_awards_cache` (" +
+                        "`subjectType` TEXT NOT NULL, " +
+                        "`tmdbId` TEXT NOT NULL, " +
+                        "`awards` TEXT NOT NULL, " +
+                        "`confirmed` INTEGER NOT NULL, " +
+                        "`fetchedAt` INTEGER NOT NULL, " +
+                        "PRIMARY KEY(`subjectType`, `tmdbId`))"
+                )
+            }
+        }
+
     val ALL_MIGRATIONS =
         arrayOf(
             MIGRATION_1_2,
@@ -1557,5 +1572,6 @@ object DatabaseMigrations {
             MIGRATION_67_68,
             MIGRATION_68_69,
             MIGRATION_69_70,
+            MIGRATION_70_71,
         )
 }

--- a/app/src/main/java/com/makd/afinity/data/database/dao/WikidataAwardsDao.kt
+++ b/app/src/main/java/com/makd/afinity/data/database/dao/WikidataAwardsDao.kt
@@ -1,0 +1,21 @@
+package com.makd.afinity.data.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.makd.afinity.data.database.entities.WikidataAwardsCacheEntity
+
+@Dao
+interface WikidataAwardsDao {
+
+    @Query(
+        "SELECT * FROM wikidata_awards_cache WHERE subjectType = :subjectType AND tmdbId = :tmdbId"
+    )
+    suspend fun getAwards(subjectType: String, tmdbId: String): WikidataAwardsCacheEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertOrUpdateAwards(awards: WikidataAwardsCacheEntity)
+
+    @Query("DELETE FROM wikidata_awards_cache") suspend fun clearAll()
+}

--- a/app/src/main/java/com/makd/afinity/data/database/entities/WikidataAwardsCacheEntity.kt
+++ b/app/src/main/java/com/makd/afinity/data/database/entities/WikidataAwardsCacheEntity.kt
@@ -1,0 +1,13 @@
+package com.makd.afinity.data.database.entities
+
+import androidx.room.Entity
+import com.makd.afinity.data.models.wikidata.WikidataAward
+
+@Entity(tableName = "wikidata_awards_cache", primaryKeys = ["subjectType", "tmdbId"])
+data class WikidataAwardsCacheEntity(
+    val subjectType: String,
+    val tmdbId: String,
+    val awards: List<WikidataAward> = emptyList(),
+    val confirmed: Boolean = false,
+    val fetchedAt: Long = System.currentTimeMillis(),
+)

--- a/app/src/main/java/com/makd/afinity/data/models/extensions/JellyfinModelExtensions.kt
+++ b/app/src/main/java/com/makd/afinity/data/models/extensions/JellyfinModelExtensions.kt
@@ -355,6 +355,7 @@ fun BaseItemDto.toAfinityPersonDetail(baseUrl: String): AfinityPersonDetail {
         endDate = endDate,
         productionLocations = productionLocations ?: emptyList(),
         externalUrls = externalUrls?.map { it.toAfinityExternalUrl() },
+        providerIds = providerIds?.mapNotNull { (key, value) -> value?.let { key to it } }?.toMap(),
         favorite = userData?.isFavorite ?: false,
     )
 }

--- a/app/src/main/java/com/makd/afinity/data/models/mdblist/MdbListUser.kt
+++ b/app/src/main/java/com/makd/afinity/data/models/mdblist/MdbListUser.kt
@@ -1,0 +1,16 @@
+package com.makd.afinity.data.models.mdblist
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MdbListUser(
+    @SerialName("api_requests") val apiRequests: Int? = null,
+    @SerialName("api_requests_count") val apiRequestsCount: Int? = null,
+    @SerialName("patron_status") val patronStatus: String? = null,
+)
+
+data class MdbListUsage(val used: Int, val limit: Int) {
+    val remaining: Int
+        get() = (limit - used).coerceAtLeast(0)
+}

--- a/app/src/main/java/com/makd/afinity/data/models/media/AfinityPersonDetail.kt
+++ b/app/src/main/java/com/makd/afinity/data/models/media/AfinityPersonDetail.kt
@@ -12,5 +12,6 @@ data class AfinityPersonDetail(
     val endDate: LocalDateTime?,
     val productionLocations: List<String>,
     val externalUrls: List<AfinityExternalUrl>?,
+    val providerIds: Map<String, String>? = null,
     val favorite: Boolean = false,
 )

--- a/app/src/main/java/com/makd/afinity/data/models/wikidata/SparqlResponse.kt
+++ b/app/src/main/java/com/makd/afinity/data/models/wikidata/SparqlResponse.kt
@@ -1,0 +1,11 @@
+package com.makd.afinity.data.models.wikidata
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SparqlResponse(val results: SparqlResults = SparqlResults())
+
+@Serializable
+data class SparqlResults(val bindings: List<Map<String, SparqlValue>> = emptyList())
+
+@Serializable data class SparqlValue(val value: String? = null)

--- a/app/src/main/java/com/makd/afinity/data/models/wikidata/WikidataAward.kt
+++ b/app/src/main/java/com/makd/afinity/data/models/wikidata/WikidataAward.kt
@@ -1,0 +1,48 @@
+package com.makd.afinity.data.models.wikidata
+
+import kotlinx.serialization.Serializable
+
+enum class WikidataSubjectType(val value: String) {
+    MOVIE("movie"),
+    TV("tv"),
+    PERSON("person");
+
+    companion object {
+        fun fromValue(value: String): WikidataSubjectType? =
+            entries.firstOrNull { it.value == value }
+    }
+}
+
+@Serializable
+enum class AwardResult {
+    WON,
+    NOMINATED,
+}
+
+@Serializable
+data class WikidataAward(
+    val name: String,
+    val result: AwardResult,
+    val year: Int? = null,
+    val recipients: List<String> = emptyList(),
+    val works: List<String> = emptyList(),
+)
+
+@Serializable
+data class WikidataAwards(
+    val awards: List<WikidataAward> = emptyList(),
+    val confirmed: Boolean = false,
+) {
+    val wins: Int
+        get() = awards.count { it.result == AwardResult.WON }
+
+    val nominations: Int
+        get() = awards.count { it.result == AwardResult.NOMINATED }
+
+    val found: Boolean
+        get() = awards.isNotEmpty()
+
+    companion object {
+        val UNCONFIRMED = WikidataAwards(confirmed = false)
+    }
+}

--- a/app/src/main/java/com/makd/afinity/data/network/MdbListApiService.kt
+++ b/app/src/main/java/com/makd/afinity/data/network/MdbListApiService.kt
@@ -1,9 +1,11 @@
 package com.makd.afinity.data.network
 
 import com.makd.afinity.data.models.mdblist.MdbListApiResult
+import com.makd.afinity.data.models.mdblist.MdbListUser
 import okhttp3.ResponseBody
 import retrofit2.Response
 import retrofit2.http.GET
+import retrofit2.http.Headers
 import retrofit2.http.Path
 import retrofit2.http.Query
 
@@ -18,4 +20,8 @@ interface MdbListApiService {
 
     @GET("user/")
     suspend fun validateApiKey(@Query("apikey") apiKey: String): Response<ResponseBody>
+
+    @Headers("Cache-Control: no-cache")
+    @GET("user/")
+    suspend fun getUser(@Query("apikey") apiKey: String): MdbListUser
 }

--- a/app/src/main/java/com/makd/afinity/data/network/WikidataApiService.kt
+++ b/app/src/main/java/com/makd/afinity/data/network/WikidataApiService.kt
@@ -1,0 +1,9 @@
+package com.makd.afinity.data.network
+
+import com.makd.afinity.data.models.wikidata.SparqlResponse
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface WikidataApiService {
+    @GET("sparql") suspend fun query(@Query("query") sparql: String): SparqlResponse
+}

--- a/app/src/main/java/com/makd/afinity/data/network/WikidataAwardParser.kt
+++ b/app/src/main/java/com/makd/afinity/data/network/WikidataAwardParser.kt
@@ -1,0 +1,80 @@
+package com.makd.afinity.data.network
+
+import com.makd.afinity.data.models.wikidata.AwardResult
+import com.makd.afinity.data.models.wikidata.SparqlResponse
+import com.makd.afinity.data.models.wikidata.SparqlValue
+import com.makd.afinity.data.models.wikidata.WikidataAward
+import com.makd.afinity.data.models.wikidata.WikidataAwards
+import com.makd.afinity.data.models.wikidata.WikidataSubjectType
+
+object WikidataAwardParser {
+
+    private val QID_PATTERN = Regex("^Q\\d+$")
+
+    private data class GroupKey(val name: String, val result: AwardResult, val year: Int?)
+
+    fun parse(response: SparqlResponse, subjectType: WikidataSubjectType): WikidataAwards {
+        val isPerson = subjectType == WikidataSubjectType.PERSON
+        val detailKey = if (isPerson) "workLabel" else "personLabel"
+
+        val grouped = LinkedHashMap<GroupKey, MutableList<String>>()
+
+        for (row in response.results.bindings) {
+            val name = row.literal("awardLabel") ?: continue
+            val result = row.literal("result")?.toAwardResult() ?: continue
+            if (QID_PATTERN.matches(name)) continue
+
+            val year = row.literal("year")?.toIntOrNull()
+            val details = grouped.getOrPut(GroupKey(name, result, year)) { mutableListOf() }
+
+            val detail = row.literal(detailKey) ?: continue
+            if (QID_PATTERN.matches(detail)) continue
+            if (detail !in details) details.add(detail)
+        }
+
+        val wonKeys =
+            grouped.keys
+                .filter { it.result == AwardResult.WON }
+                .map { it.name to it.year }
+                .toSet()
+
+        for ((key, details) in grouped) {
+            if (key.result != AwardResult.NOMINATED) continue
+            if ((key.name to key.year) !in wonKeys) continue
+            val wonDetails = grouped[key.copy(result = AwardResult.WON)] ?: continue
+            details.forEach { if (it !in wonDetails) wonDetails.add(it) }
+        }
+
+        val awards =
+            grouped
+                .filterNot { (key, _) ->
+                    key.result == AwardResult.NOMINATED && (key.name to key.year) in wonKeys
+                }
+                .map { (key, details) ->
+                    WikidataAward(
+                        name = key.name,
+                        result = key.result,
+                        year = key.year,
+                        recipients = if (isPerson) emptyList() else details.toList(),
+                        works = if (isPerson) details.toList() else emptyList(),
+                    )
+                }
+                .sortedWith(
+                    compareByDescending<WikidataAward> { it.year ?: 0 }
+                        .thenBy { if (it.result == AwardResult.WON) 0 else 1 }
+                        .thenBy { it.name }
+                )
+
+        return WikidataAwards(awards = awards, confirmed = true)
+    }
+
+    private fun Map<String, SparqlValue>.literal(key: String): String? =
+        this[key]?.value?.takeIf { it.isNotBlank() }
+
+    private fun String.toAwardResult(): AwardResult? =
+        when (this) {
+            WikidataAwardQueries.RESULT_WON -> AwardResult.WON
+            WikidataAwardQueries.RESULT_NOMINATED -> AwardResult.NOMINATED
+            else -> null
+        }
+}

--- a/app/src/main/java/com/makd/afinity/data/network/WikidataAwardQueries.kt
+++ b/app/src/main/java/com/makd/afinity/data/network/WikidataAwardQueries.kt
@@ -1,0 +1,85 @@
+package com.makd.afinity.data.network
+
+import com.makd.afinity.data.models.wikidata.WikidataSubjectType
+
+object WikidataAwardQueries {
+
+    private const val TMDB_MOVIE_ID = "P4947"
+    private const val TMDB_SERIES_ID = "P4983"
+    private const val TMDB_PERSON_ID = "P4985"
+    private const val LABEL_LANGUAGES = "en,mul"
+
+    const val RESULT_WON = "Won"
+    const val RESULT_NOMINATED = "Nominated"
+
+    fun build(subjectType: WikidataSubjectType, tmdbId: String): String =
+        when (subjectType) {
+            WikidataSubjectType.PERSON -> buildPersonQuery(tmdbId)
+            WikidataSubjectType.MOVIE -> buildTitleQuery(TMDB_MOVIE_ID, tmdbId)
+            WikidataSubjectType.TV -> buildTitleQuery(TMDB_SERIES_ID, tmdbId)
+        }
+
+    private fun buildTitleQuery(idProperty: String, tmdbId: String): String {
+        val id = escape(tmdbId)
+        return """
+            SELECT DISTINCT ?award ?awardLabel ?result ?year ?personLabel WHERE {
+              ?film wdt:$idProperty "$id" .
+              {
+                ?film p:P166 ?st1 . ?st1 ps:P166 ?award .
+                OPTIONAL { ?st1 pq:P585 ?d1 . BIND(YEAR(?d1) AS ?year) }
+                BIND("$RESULT_WON" AS ?result)
+              }
+              UNION
+              {
+                ?film p:P1411 ?st2 . ?st2 ps:P1411 ?award .
+                OPTIONAL { ?st2 pq:P585 ?d2 . BIND(YEAR(?d2) AS ?year) }
+                BIND("$RESULT_NOMINATED" AS ?result)
+              }
+              UNION
+              {
+                ?person p:P166 ?st3 . ?st3 ps:P166 ?award ; pq:P1686 ?film .
+                OPTIONAL { ?st3 pq:P585 ?d3 . BIND(YEAR(?d3) AS ?year) }
+                BIND("$RESULT_WON" AS ?result)
+              }
+              UNION
+              {
+                ?person p:P1411 ?st4 . ?st4 ps:P1411 ?award ; pq:P1686 ?film .
+                OPTIONAL { ?st4 pq:P585 ?d4 . BIND(YEAR(?d4) AS ?year) }
+                BIND("$RESULT_NOMINATED" AS ?result)
+              }
+              SERVICE wikibase:label { bd:serviceParam wikibase:language "$LABEL_LANGUAGES". }
+            }
+        """
+            .trimIndent()
+    }
+
+    private fun buildPersonQuery(tmdbId: String): String {
+        val id = escape(tmdbId)
+        return """
+            SELECT DISTINCT ?award ?awardLabel ?result ?year ?workLabel WHERE {
+              ?person wdt:$TMDB_PERSON_ID "$id" .
+              {
+                ?person p:P166 ?st1 . ?st1 ps:P166 ?award .
+                OPTIONAL { ?st1 pq:P585 ?d1 . BIND(YEAR(?d1) AS ?year) }
+                OPTIONAL { ?st1 pq:P1686 ?work . }
+                BIND("$RESULT_WON" AS ?result)
+              }
+              UNION
+              {
+                ?person p:P1411 ?st2 . ?st2 ps:P1411 ?award .
+                OPTIONAL { ?st2 pq:P585 ?d2 . BIND(YEAR(?d2) AS ?year) }
+                OPTIONAL { ?st2 pq:P1686 ?work . }
+                BIND("$RESULT_NOMINATED" AS ?result)
+              }
+              SERVICE wikibase:label { bd:serviceParam wikibase:language "$LABEL_LANGUAGES". }
+            }
+        """
+            .trimIndent()
+    }
+
+    fun isValidTmdbId(tmdbId: String?): Boolean =
+        !tmdbId.isNullOrBlank() && tmdbId.all { it.isDigit() }
+
+    private fun escape(value: String): String =
+        value.replace("\\", "\\\\").replace("\"", "\\\"")
+}

--- a/app/src/main/java/com/makd/afinity/data/repository/DatabaseRepository.kt
+++ b/app/src/main/java/com/makd/afinity/data/repository/DatabaseRepository.kt
@@ -3,6 +3,7 @@ package com.makd.afinity.data.repository
 import com.makd.afinity.data.database.entities.AfinitySourceDto
 import com.makd.afinity.data.database.entities.DownloadDto
 import com.makd.afinity.data.database.entities.ItemMetadataCacheEntity
+import com.makd.afinity.data.database.entities.WikidataAwardsCacheEntity
 import com.makd.afinity.data.models.download.DownloadStatus
 import com.makd.afinity.data.models.media.AfinityEpisode
 import com.makd.afinity.data.models.media.AfinityItem
@@ -268,6 +269,10 @@ interface DatabaseRepository {
     ): ItemMetadataCacheEntity?
 
     suspend fun insertItemMetadata(metadata: ItemMetadataCacheEntity)
+
+    suspend fun getWikidataAwards(subjectType: String, tmdbId: String): WikidataAwardsCacheEntity?
+
+    suspend fun insertWikidataAwards(awards: WikidataAwardsCacheEntity)
 
     suspend fun insertMusicTrack(track: AfinityTrack, serverId: String, userId: String)
 

--- a/app/src/main/java/com/makd/afinity/data/repository/FieldSets.kt
+++ b/app/src/main/java/com/makd/afinity/data/repository/FieldSets.kt
@@ -72,6 +72,7 @@ object FieldSets {
             ItemFields.OVERVIEW,
             ItemFields.EXTERNAL_URLS,
             ItemFields.PRODUCTION_LOCATIONS,
+            ItemFields.PROVIDER_IDS,
         )
 
     val REFRESH_USER_DATA = emptyList<ItemFields>()

--- a/app/src/main/java/com/makd/afinity/data/repository/PreferencesRepository.kt
+++ b/app/src/main/java/com/makd/afinity/data/repository/PreferencesRepository.kt
@@ -330,6 +330,18 @@ interface PreferencesRepository {
 
     fun getShowRatingsFlow(): Flow<Boolean>
 
+    suspend fun setShowAwards(enabled: Boolean)
+
+    suspend fun getShowAwards(): Boolean
+
+    fun getShowAwardsFlow(): Flow<Boolean>
+
+    suspend fun setWikidataEnabled(enabled: Boolean)
+
+    suspend fun getWikidataEnabled(): Boolean
+
+    fun getWikidataEnabledFlow(): Flow<Boolean>
+
     suspend fun setNotificationPermissionDeclined(declined: Boolean)
 
     suspend fun getNotificationPermissionDeclined(): Boolean

--- a/app/src/main/java/com/makd/afinity/data/repository/impl/DatabaseRepositoryImpl.kt
+++ b/app/src/main/java/com/makd/afinity/data/repository/impl/DatabaseRepositoryImpl.kt
@@ -15,6 +15,7 @@ import com.makd.afinity.data.database.dao.ShowDao
 import com.makd.afinity.data.database.dao.SourceDao
 import com.makd.afinity.data.database.dao.UserDao
 import com.makd.afinity.data.database.dao.UserDataDao
+import com.makd.afinity.data.database.dao.WikidataAwardsDao
 import com.makd.afinity.data.database.entities.AfinityEpisodeDto
 import com.makd.afinity.data.database.entities.AfinityMovieDto
 import com.makd.afinity.data.database.entities.AfinitySeasonDto
@@ -23,6 +24,7 @@ import com.makd.afinity.data.database.entities.AfinitySourceDto
 import com.makd.afinity.data.database.entities.DownloadDto
 import com.makd.afinity.data.database.entities.ItemMetadataCacheEntity
 import com.makd.afinity.data.database.entities.MusicLyricsEntity
+import com.makd.afinity.data.database.entities.WikidataAwardsCacheEntity
 import com.makd.afinity.data.database.entities.toAfinityAlbum
 import com.makd.afinity.data.database.entities.toAfinityEpisodeDto
 import com.makd.afinity.data.database.entities.toAfinityMediaStreamDto
@@ -90,6 +92,7 @@ constructor(
     private val userDataDao: UserDataDao,
     private val serverDatabaseDao: ServerDatabaseDao,
     private val itemMetadataCacheDao: ItemMetadataCacheDao,
+    private val wikidataAwardsDao: WikidataAwardsDao,
     private val musicTrackDao: MusicTrackDao,
     private val musicAlbumDao: MusicAlbumDao,
     private val musicLyricsDao: MusicLyricsDao,
@@ -856,6 +859,17 @@ constructor(
 
     override suspend fun insertItemMetadata(metadata: ItemMetadataCacheEntity) {
         itemMetadataCacheDao.insertOrUpdateMetadata(metadata)
+    }
+
+    override suspend fun getWikidataAwards(
+        subjectType: String,
+        tmdbId: String,
+    ): WikidataAwardsCacheEntity? {
+        return wikidataAwardsDao.getAwards(subjectType, tmdbId)
+    }
+
+    override suspend fun insertWikidataAwards(awards: WikidataAwardsCacheEntity) {
+        wikidataAwardsDao.insertOrUpdateAwards(awards)
     }
 
     override suspend fun insertMusicTrack(track: AfinityTrack, serverId: String, userId: String) {

--- a/app/src/main/java/com/makd/afinity/data/repository/impl/PreferencesRepositoryImpl.kt
+++ b/app/src/main/java/com/makd/afinity/data/repository/impl/PreferencesRepositoryImpl.kt
@@ -136,6 +136,8 @@ constructor(@param:AppPreferences private val dataStore: DataStore<Preferences>)
         val BUFFER_SIZE_MB = intPreferencesKey("buffer_size_mb")
 
         val SHOW_RATINGS = booleanPreferencesKey("show_ratings")
+        val SHOW_AWARDS = booleanPreferencesKey("show_awards")
+        val WIKIDATA_ENABLED = booleanPreferencesKey("wikidata_enabled")
     }
 
     override suspend fun setCurrentServerId(serverId: String?) {
@@ -943,6 +945,30 @@ constructor(@param:AppPreferences private val dataStore: DataStore<Preferences>)
 
     override suspend fun getShowRatings(): Boolean {
         return dataStore.data.first()[Keys.SHOW_RATINGS] ?: true
+    }
+
+    override suspend fun setShowAwards(enabled: Boolean) {
+        dataStore.edit { preferences -> preferences[Keys.SHOW_AWARDS] = enabled }
+    }
+
+    override suspend fun getShowAwards(): Boolean {
+        return dataStore.data.first()[Keys.SHOW_AWARDS] ?: true
+    }
+
+    override fun getShowAwardsFlow(): Flow<Boolean> {
+        return dataStore.data.map { preferences -> preferences[Keys.SHOW_AWARDS] ?: true }
+    }
+
+    override suspend fun setWikidataEnabled(enabled: Boolean) {
+        dataStore.edit { preferences -> preferences[Keys.WIKIDATA_ENABLED] = enabled }
+    }
+
+    override suspend fun getWikidataEnabled(): Boolean {
+        return dataStore.data.first()[Keys.WIKIDATA_ENABLED] ?: false
+    }
+
+    override fun getWikidataEnabledFlow(): Flow<Boolean> {
+        return dataStore.data.map { preferences -> preferences[Keys.WIKIDATA_ENABLED] ?: false }
     }
 
     override fun getShowRatingsFlow(): Flow<Boolean> {

--- a/app/src/main/java/com/makd/afinity/data/repository/livetv/JellyfinLiveTvRepository.kt
+++ b/app/src/main/java/com/makd/afinity/data/repository/livetv/JellyfinLiveTvRepository.kt
@@ -12,6 +12,7 @@ import com.makd.afinity.data.repository.media.MediaRepository
 import com.makd.afinity.data.repository.userdata.UserDataRepository
 import com.makd.afinity.di.NetworkModule
 import com.makd.afinity.util.MediaCapabilities
+import com.makd.afinity.util.redactUrl
 import org.jellyfin.sdk.Jellyfin
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.operations.LiveTvApi
@@ -379,7 +380,7 @@ constructor(
                 }
             }
 
-            Timber.d("Selected Live TV stream: method=$playMethod, url=$streamUrl")
+            Timber.d("Selected Live TV stream: method=$playMethod, url=${redactUrl(streamUrl)}")
             LiveTvPlaybackInfo(
                 streamUrl = streamUrl,
                 mediaSourceId = mediaSourceId,

--- a/app/src/main/java/com/makd/afinity/data/repository/wikidata/WikidataAwardsRepository.kt
+++ b/app/src/main/java/com/makd/afinity/data/repository/wikidata/WikidataAwardsRepository.kt
@@ -1,0 +1,133 @@
+package com.makd.afinity.data.repository.wikidata
+
+import com.makd.afinity.data.database.entities.WikidataAwardsCacheEntity
+import com.makd.afinity.data.models.wikidata.WikidataAwards
+import com.makd.afinity.data.models.wikidata.WikidataSubjectType
+import com.makd.afinity.data.network.WikidataApiService
+import com.makd.afinity.data.network.WikidataAwardParser
+import com.makd.afinity.data.network.WikidataAwardQueries
+import com.makd.afinity.data.repository.DatabaseRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.cancellation.CancellationException
+
+@Singleton
+class WikidataAwardsRepository
+@Inject
+constructor(
+    private val wikidataApiService: WikidataApiService,
+    private val databaseRepository: DatabaseRepository,
+) {
+
+    private val inFlight = mutableMapOf<String, Mutex>()
+    private val inFlightLock = Mutex()
+    private val seriesTmdbIds = ConcurrentHashMap<UUID, String>()
+
+    suspend fun resolveSeriesTmdbId(seriesId: UUID, resolve: suspend () -> String?): String? {
+        seriesTmdbIds[seriesId]?.let { cached ->
+            return cached.takeIf { it != NO_TMDB_ID }
+        }
+        val resolved = resolve()
+        seriesTmdbIds[seriesId] = resolved ?: NO_TMDB_ID
+        return resolved
+    }
+
+    suspend fun getAwards(subjectType: WikidataSubjectType, tmdbId: String?): WikidataAwards {
+        if (!WikidataAwardQueries.isValidTmdbId(tmdbId)) return WikidataAwards.UNCONFIRMED
+        val id = tmdbId!!
+
+        cached(subjectType, id)?.let { return it }
+
+        val key = "${subjectType.value}-$id"
+        val gate = inFlightLock.withLock { inFlight.getOrPut(key) { Mutex() } }
+        try {
+            gate.withLock {
+                cached(subjectType, id)?.let { return it }
+
+                val fetched = fetch(subjectType, id)
+                persist(subjectType, id, fetched)
+                return fetched
+            }
+        } finally {
+            inFlightLock.withLock { if (!gate.isLocked) inFlight.remove(key) }
+        }
+    }
+
+    suspend fun cachedAwards(
+        subjectType: WikidataSubjectType,
+        tmdbId: String?,
+    ): WikidataAwards? {
+        if (!WikidataAwardQueries.isValidTmdbId(tmdbId)) return null
+        return cached(subjectType, tmdbId!!)
+    }
+
+    private suspend fun cached(
+        subjectType: WikidataSubjectType,
+        tmdbId: String,
+    ): WikidataAwards? {
+        val entity =
+            runCatching { databaseRepository.getWikidataAwards(subjectType.value, tmdbId) }
+                .getOrNull() ?: return null
+
+        if (entity.isExpired()) return null
+
+        return WikidataAwards(awards = entity.awards, confirmed = entity.confirmed)
+    }
+
+    private suspend fun fetch(
+        subjectType: WikidataSubjectType,
+        tmdbId: String,
+    ): WikidataAwards =
+        withContext(Dispatchers.IO) {
+            try {
+                val response =
+                    wikidataApiService.query(WikidataAwardQueries.build(subjectType, tmdbId))
+                WikidataAwardParser.parse(response, subjectType)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.w(e, "Wikidata awards lookup failed for ${subjectType.value}:$tmdbId")
+                WikidataAwards.UNCONFIRMED
+            }
+        }
+
+    private suspend fun persist(
+        subjectType: WikidataSubjectType,
+        tmdbId: String,
+        awards: WikidataAwards,
+    ) {
+        runCatching {
+            databaseRepository.insertWikidataAwards(
+                WikidataAwardsCacheEntity(
+                    subjectType = subjectType.value,
+                    tmdbId = tmdbId,
+                    awards = awards.awards,
+                    confirmed = awards.confirmed,
+                )
+            )
+        }
+    }
+
+    private fun WikidataAwardsCacheEntity.isExpired(): Boolean {
+        val age = System.currentTimeMillis() - fetchedAt
+        return when {
+            awards.isNotEmpty() -> age > POSITIVE_TTL_MS
+            confirmed -> age > NEGATIVE_TTL_MS
+            else -> age > RETRY_TTL_MS
+        }
+    }
+
+    companion object {
+        private const val NO_TMDB_ID = ""
+        const val POSITIVE_TTL_MS = 180L * 24L * 60L * 60L * 1000L
+        const val NEGATIVE_TTL_MS = 30L * 24L * 60L * 60L * 1000L
+        const val RETRY_TTL_MS = 60L * 60L * 1000L
+    }
+}

--- a/app/src/main/java/com/makd/afinity/data/workers/MediaDownloadWorker.kt
+++ b/app/src/main/java/com/makd/afinity/data/workers/MediaDownloadWorker.kt
@@ -40,6 +40,7 @@ import com.makd.afinity.data.repository.segments.SegmentsRepository
 import com.makd.afinity.di.DownloadClient
 import com.makd.afinity.util.formatFileSize
 import com.makd.afinity.util.parseDashlessUuid
+import com.makd.afinity.util.redactUrl
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.Dispatchers
@@ -289,7 +290,7 @@ constructor(
 
                         val existingFileSize = if (outputFile.exists()) outputFile.length() else 0L
 
-                        Timber.d("Downloading from: $downloadUrl")
+                        Timber.d("Downloading from: ${redactUrl(downloadUrl)}")
                         Timber.d("Saving to: ${outputFile.absolutePath}")
                         Timber.d("Resuming from byte: $existingFileSize")
 

--- a/app/src/main/java/com/makd/afinity/di/DatabaseModule.kt
+++ b/app/src/main/java/com/makd/afinity/di/DatabaseModule.kt
@@ -29,6 +29,7 @@ import com.makd.afinity.data.database.dao.SourceDao
 import com.makd.afinity.data.database.dao.TopPeopleDao
 import com.makd.afinity.data.database.dao.UserDao
 import com.makd.afinity.data.database.dao.UserDataDao
+import com.makd.afinity.data.database.dao.WikidataAwardsDao
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -115,6 +116,11 @@ object DatabaseModule {
     @Provides
     fun provideItemMetadataCacheDao(database: AfinityDatabase): ItemMetadataCacheDao {
         return database.itemMetadataCacheDao()
+    }
+
+    @Provides
+    fun provideWikidataAwardsDao(database: AfinityDatabase): WikidataAwardsDao {
+        return database.wikidataAwardsDao()
     }
 
     @Provides

--- a/app/src/main/java/com/makd/afinity/di/NetworkModule.kt
+++ b/app/src/main/java/com/makd/afinity/di/NetworkModule.kt
@@ -12,10 +12,12 @@ import com.makd.afinity.data.network.MdbListApiService
 import com.makd.afinity.data.network.OmdbApiService
 import com.makd.afinity.data.network.SeerrCookieJar
 import com.makd.afinity.data.network.TmdbApiService
+import com.makd.afinity.data.network.WikidataApiService
 import com.makd.afinity.data.network.resolveDynamicBaseUrl
 import com.makd.afinity.data.network.rewriteWithRequestPathAndQuery
 import com.makd.afinity.data.repository.SecurePreferencesRepository
 import com.makd.afinity.util.NetworkConnectivityMonitor
+import com.makd.afinity.util.redactSecrets
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -75,6 +77,8 @@ import kotlin.time.Duration.Companion.seconds
 @Qualifier @Retention(AnnotationRetention.BINARY) annotation class AudnexusClient
 
 @Qualifier @Retention(AnnotationRetention.BINARY) annotation class ProberClient
+
+@Qualifier @Retention(AnnotationRetention.BINARY) annotation class WikidataClient
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -143,11 +147,7 @@ object NetworkModule {
 
         if (BuildConfig.DEBUG) {
             val loggingInterceptor = HttpLoggingInterceptor { message ->
-                val sanitizedMessage =
-                    message.replace(
-                        Regex("(?i)(api_key|token|accessToken)=[^&\\s]+"),
-                        "$1=[REDACTED]",
-                    )
+                val sanitizedMessage = redactSecrets(message)
                 Timber.tag("Jellyfin-HTTP").d(sanitizedMessage)
             }
                 .apply {
@@ -167,6 +167,9 @@ object NetworkModule {
 
     private val apiUserAgent =
         "AFinity/${BuildConfig.VERSION_NAME} (Android ${Build.VERSION.RELEASE}; ${Build.MODEL})"
+
+    private val wikidataUserAgent =
+        "AFinity/${BuildConfig.VERSION_NAME} (https://github.com/MakD/AFinity; award lookups, cached client-side)"
 
     @Provides
     @Singleton
@@ -267,11 +270,7 @@ object NetworkModule {
 
         if (BuildConfig.DEBUG) {
             val loggingInterceptor = HttpLoggingInterceptor { message ->
-                val sanitizedMessage =
-                    message.replace(
-                        Regex("(?i)(api_key|token|accessToken)=[^&\\s]+"),
-                        "$1=[REDACTED]",
-                    )
+                val sanitizedMessage = redactSecrets(message)
 
                 if (
                     sanitizedMessage.contains("ERROR") ||
@@ -768,5 +767,46 @@ object NetworkModule {
     @Singleton
     fun provideAudnexusApiService(@AudnexusClient retrofit: Retrofit): AudnexusApiService {
         return retrofit.create(AudnexusApiService::class.java)
+    }
+
+    @Provides
+    @Singleton
+    @WikidataClient
+    fun provideWikidataRetrofit(baseOkHttpClient: OkHttpClient): Retrofit {
+        val contentType = "application/json".toMediaType()
+        val json = Json {
+            ignoreUnknownKeys = true
+            isLenient = true
+        }
+
+        val wikidataClient =
+            baseOkHttpClient
+                .newBuilder()
+                .connectTimeout(10, TimeUnit.SECONDS)
+                .readTimeout(20, TimeUnit.SECONDS)
+                .callTimeout(25, TimeUnit.SECONDS)
+                .addInterceptor { chain ->
+                    chain.proceed(
+                        chain
+                            .request()
+                            .newBuilder()
+                            .header("User-Agent", wikidataUserAgent)
+                            .header("Accept", "application/sparql-results+json")
+                            .build()
+                    )
+                }
+                .build()
+
+        return Retrofit.Builder()
+            .baseUrl("https://query.wikidata.org/")
+            .client(wikidataClient)
+            .addConverterFactory(json.asConverterFactory(contentType))
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideWikidataApiService(@WikidataClient retrofit: Retrofit): WikidataApiService {
+        return retrofit.create(WikidataApiService::class.java)
     }
 }

--- a/app/src/main/java/com/makd/afinity/navigation/MainNavigation.kt
+++ b/app/src/main/java/com/makd/afinity/navigation/MainNavigation.kt
@@ -123,6 +123,8 @@ import timber.log.Timber
 val LocalPlayerOffset = compositionLocalOf { 0.dp }
 val LocalShowRatings = compositionLocalOf { true }
 
+val LocalShowAwards = compositionLocalOf { true }
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MainNavigation(
@@ -149,6 +151,7 @@ fun MainNavigation(
         viewModel.audiobookshelfPlaybackManager.playbackState.collectAsStateWithLifecycle()
     val musicPlaybackState by viewModel.musicPlaybackManager.state.collectAsStateWithLifecycle()
     val showRatings by viewModel.showRatings.collectAsStateWithLifecycle()
+    val showAwards by viewModel.showAwards.collectAsStateWithLifecycle()
     val navigationDrawerEnabled by viewModel.navigationDrawerEnabled.collectAsStateWithLifecycle()
     val librariesInDrawer by viewModel.librariesInDrawer.collectAsStateWithLifecycle()
     val serverName by viewModel.serverName.collectAsStateWithLifecycle()
@@ -396,6 +399,7 @@ fun MainNavigation(
                 CompositionLocalProvider(
                     LocalPlayerOffset provides globalPlayerOffset,
                     LocalShowRatings provides showRatings,
+                    LocalShowAwards provides showAwards,
                 ) {
                     SharedTransitionLayout {
                         Box(modifier = Modifier.fillMaxSize()) {

--- a/app/src/main/java/com/makd/afinity/navigation/MainNavigationViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/navigation/MainNavigationViewModel.kt
@@ -74,6 +74,15 @@ constructor(
                 initialValue = true,
             )
 
+    val showAwards =
+        preferencesRepository
+            .getShowAwardsFlow()
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5000),
+                initialValue = true,
+            )
+
     val navigationDrawerEnabled =
         preferencesRepository
             .getNavigationDrawerEnabledFlow()

--- a/app/src/main/java/com/makd/afinity/ui/item/ItemDetailScreen.kt
+++ b/app/src/main/java/com/makd/afinity/ui/item/ItemDetailScreen.kt
@@ -89,6 +89,7 @@ import com.makd.afinity.data.models.media.AfinityShow
 import com.makd.afinity.data.models.media.AfinityVideo
 import com.makd.afinity.data.models.media.AfinityVideoPlaylist
 import com.makd.afinity.data.models.tmdb.TmdbReview
+import com.makd.afinity.data.models.wikidata.WikidataAwards
 import com.makd.afinity.navigation.Destination
 import com.makd.afinity.navigation.LocalPlayerOffset
 import com.makd.afinity.ui.admin.refresh.RefreshMetadataDialog
@@ -208,6 +209,7 @@ fun ItemDetailScreen(
                     mdbRatings = uiState.mdbRatings,
                     mdbRatingBadges = uiState.mdbRatingBadges,
                     omdbAwards = uiState.omdbAwards,
+                    wikidataAwards = uiState.wikidataAwards,
                     isRatingsFromCache = uiState.isRatingsFromCache,
                     movieParts = uiState.movieParts,
                     onPlayClick = { item, selection -> interceptPlayClick(item, selection) },
@@ -416,6 +418,7 @@ private fun ItemDetailContent(
     mdbRatings: List<MdbListRating>,
     mdbRatingBadges: MdbListRatingBadges,
     omdbAwards: String?,
+    wikidataAwards: WikidataAwards?,
     isRatingsFromCache: Boolean,
     movieParts: List<AfinityItem>,
     onPlayClick: (AfinityItem, PlaybackSelection?) -> Unit,
@@ -451,6 +454,7 @@ private fun ItemDetailContent(
                 mdbRatings = mdbRatings,
                 mdbRatingBadges = mdbRatingBadges,
                 omdbAwards = omdbAwards,
+                wikidataAwards = wikidataAwards,
                 isRatingsFromCache = isRatingsFromCache,
                 movieParts = movieParts,
                 onPlayClick = onPlayClick,
@@ -480,6 +484,7 @@ private fun ItemDetailContent(
                 mdbRatings = mdbRatings,
                 mdbRatingBadges = mdbRatingBadges,
                 omdbAwards = omdbAwards,
+                wikidataAwards = wikidataAwards,
                 isRatingsFromCache = isRatingsFromCache,
                 movieParts = movieParts,
                 onPlayClick = onPlayClick,
@@ -524,6 +529,7 @@ private fun LandscapeItemDetailContent(
     mdbRatings: List<MdbListRating>,
     mdbRatingBadges: MdbListRatingBadges,
     omdbAwards: String?,
+    wikidataAwards: WikidataAwards?,
     isRatingsFromCache: Boolean,
     movieParts: List<AfinityItem>,
     onPlayClick: (AfinityItem, PlaybackSelection?) -> Unit,
@@ -791,6 +797,7 @@ private fun LandscapeItemDetailContent(
                             mdbRatings = mdbRatings,
                             mdbRatingBadges = mdbRatingBadges,
                             omdbAwards = omdbAwards,
+                            wikidataAwards = wikidataAwards,
                             isRatingsFromCache = isRatingsFromCache,
                             movieParts = movieParts,
                             onPlayClick = onPlayClick,
@@ -826,6 +833,7 @@ private fun PortraitItemDetailContent(
     mdbRatings: List<MdbListRating>,
     mdbRatingBadges: MdbListRatingBadges,
     omdbAwards: String?,
+    wikidataAwards: WikidataAwards?,
     isRatingsFromCache: Boolean,
     movieParts: List<AfinityItem>,
     onPlayClick: (AfinityItem, PlaybackSelection?) -> Unit,
@@ -999,6 +1007,7 @@ private fun PortraitItemDetailContent(
                     mdbRatings = mdbRatings,
                     mdbRatingBadges = mdbRatingBadges,
                     omdbAwards = omdbAwards,
+                    wikidataAwards = wikidataAwards,
                     isRatingsFromCache = isRatingsFromCache,
                     movieParts = movieParts,
                     onPlayClick = onPlayClick,
@@ -1074,6 +1083,7 @@ private fun TypeSpecificContent(
     mdbRatings: List<MdbListRating>,
     mdbRatingBadges: MdbListRatingBadges,
     omdbAwards: String?,
+    wikidataAwards: WikidataAwards?,
     isRatingsFromCache: Boolean,
     movieParts: List<AfinityItem>,
     onPlayClick: (AfinityItem, PlaybackSelection?) -> Unit,
@@ -1098,6 +1108,7 @@ private fun TypeSpecificContent(
                 mdbRatings = mdbRatings,
                 mdbRatingBadges = mdbRatingBadges,
                 omdbAwards = omdbAwards,
+                wikidataAwards = wikidataAwards,
                 isRatingsFromCache = isRatingsFromCache,
                 onEpisodeClick = { ep ->
                     val mediaSourceId = ep.sources.firstOrNull()?.id ?: return@SeriesDetailContent
@@ -1145,6 +1156,7 @@ private fun TypeSpecificContent(
                 tmdbReviews = tmdbReviews,
                 mdbRatings = mdbRatings,
                 mdbRatingBadges = mdbRatingBadges,
+                wikidataAwards = wikidataAwards,
                 isRatingsFromCache = isRatingsFromCache,
                 onEpisodeClick = { ep -> viewModel.selectEpisode(ep) },
                 onSpecialFeatureClick = onSpecialFeatureClick,
@@ -1162,6 +1174,7 @@ private fun TypeSpecificContent(
                 mdbRatings = mdbRatings,
                 mdbRatingBadges = mdbRatingBadges,
                 omdbAwards = omdbAwards,
+                wikidataAwards = wikidataAwards,
                 isRatingsFromCache = isRatingsFromCache,
                 parts = movieParts,
                 onSpecialFeatureClick = onSpecialFeatureClick,

--- a/app/src/main/java/com/makd/afinity/ui/item/ItemDetailViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/item/ItemDetailViewModel.kt
@@ -40,6 +40,8 @@ import com.makd.afinity.data.models.media.toAfinityEpisode
 import com.makd.afinity.data.models.media.toAfinityMovie
 import com.makd.afinity.data.models.media.toAfinityShow
 import com.makd.afinity.data.models.tmdb.TmdbReview
+import com.makd.afinity.data.models.wikidata.WikidataAwards
+import com.makd.afinity.data.models.wikidata.WikidataSubjectType
 import com.makd.afinity.data.network.TmdbApiService
 import com.makd.afinity.data.paging.EpisodesPagingSource
 import com.makd.afinity.data.repository.AppDataRepository
@@ -54,6 +56,7 @@ import com.makd.afinity.data.repository.media.MediaRepository
 import com.makd.afinity.data.repository.metadata.ItemRatingsLoader
 import com.makd.afinity.data.repository.server.ServerRepository
 import com.makd.afinity.data.repository.userdata.UserDataRepository
+import com.makd.afinity.data.repository.wikidata.WikidataAwardsRepository
 import com.makd.afinity.data.storage.StorageLocationProvider
 import com.makd.afinity.data.storage.StorageVolumeInfo
 import com.makd.afinity.data.store.ItemStore
@@ -92,10 +95,14 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
 import org.jellyfin.sdk.model.api.BaseItemKind
+import org.jellyfin.sdk.model.api.ItemFields
 import timber.log.Timber
 import java.util.UUID
 import javax.inject.Inject
 import kotlin.coroutines.cancellation.CancellationException
+
+private const val POPULATED_METADATA_TTL_MS = 48L * 60L * 60L * 1000L
+private const val EMPTY_METADATA_TTL_MS = 6L * 60L * 60L * 1000L
 
 @OptIn(FlowPreview::class)
 @HiltViewModel
@@ -126,6 +133,7 @@ constructor(
     private val networkMonitor: NetworkConnectivityMonitor,
     private val downloadPermissions: DownloadPermissions,
     private val itemStore: ItemStore,
+    private val wikidataAwardsRepository: WikidataAwardsRepository,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
@@ -207,6 +215,12 @@ constructor(
                             _uiState.value.nextEpisode == null
                     ) {
                         fetchNextEpisodeFor(item)
+                    }
+                    if (
+                        _uiState.value.wikidataAwards == null &&
+                            !_uiState.value.isLoadingWikidataAwards
+                    ) {
+                        loadWikidataAwards(item, hasInternet = true)
                     }
                     if (item !is AfinityMovie && item !is AfinityShow) return@collect
                     val s = _uiState.value
@@ -832,6 +846,9 @@ constructor(
                         fetchNextEpisodeFor(item)
                     }
                 }
+                if (item is AfinityMovie || item is AfinityShow || item is AfinitySeason) {
+                    launch { loadWikidataAwards(item, hasInternet) }
+                }
                 if (item is AfinityMovie || item is AfinityShow) {
                     if (hasInternet) {
                         launch { loadReviewsAndRatings(item) }
@@ -1069,6 +1086,54 @@ constructor(
         }
     }
 
+    private suspend fun loadWikidataAwards(item: AfinityItem, hasInternet: Boolean) {
+        if (!preferencesRepository.getShowAwards() || !preferencesRepository.getWikidataEnabled()) {
+            _uiState.update { it.copy(wikidataAwards = null, isLoadingWikidataAwards = false) }
+            return
+        }
+
+        val subject = wikidataSubjectFor(item)
+        val tmdbId = subject?.second
+        if (subject == null || tmdbId == null) {
+            _uiState.update { it.copy(wikidataAwards = null, isLoadingWikidataAwards = false) }
+            return
+        }
+
+        _uiState.update { it.copy(isLoadingWikidataAwards = true) }
+
+        val awards =
+            if (hasInternet) wikidataAwardsRepository.getAwards(subject.first, tmdbId)
+            else wikidataAwardsRepository.cachedAwards(subject.first, tmdbId)
+
+        if (_uiState.value.item?.id != item.id) return
+
+        _uiState.update {
+            it.copy(
+                wikidataAwards = awards?.takeIf { loaded -> loaded.found },
+                isLoadingWikidataAwards = false,
+            )
+        }
+    }
+
+    private suspend fun wikidataSubjectFor(item: AfinityItem): Pair<WikidataSubjectType, String?>? =
+        when (item) {
+            is AfinityMovie -> WikidataSubjectType.MOVIE to item.providerIds?.get("Tmdb")
+            is AfinityShow -> WikidataSubjectType.TV to item.providerIds?.get("Tmdb")
+            is AfinitySeason -> WikidataSubjectType.TV to seriesTmdbId(item.seriesId)
+            else -> null
+        }
+
+    private suspend fun seriesTmdbId(seriesId: UUID): String? =
+        wikidataAwardsRepository.resolveSeriesTmdbId(seriesId) {
+            runCatching {
+                mediaRepository
+                    .getItem(seriesId, listOf(ItemFields.PROVIDER_IDS))
+                    ?.providerIds
+                    ?.get("Tmdb")
+            }
+                .getOrNull()
+        }
+
     private suspend fun loadReviewsAndRatings(item: AfinityItem) {
         val userId = sessionManager.currentSession.value?.userId
         try {
@@ -1084,16 +1149,16 @@ constructor(
                 } else null
 
             val cacheAgeMs = System.currentTimeMillis() - (cachedMetadata?.lastUpdated ?: 0L)
-            val isCacheValid = cacheAgeMs < 48 * 60 * 60 * 1000L
-
-            if (
+            val cachedHasData =
                 cachedMetadata != null &&
-                    isCacheValid &&
                     (cachedMetadata.tmdbReviews.isNotEmpty() ||
                         cachedMetadata.mdbRatings.isNotEmpty() ||
                         cachedMetadata.mdbRatingBadges.hasAny ||
-                        cachedMetadata.omdbAwards != null)
-            ) {
+                        !cachedMetadata.omdbAwards.isNullOrBlank())
+            val cacheTtlMs = if (cachedHasData) POPULATED_METADATA_TTL_MS else EMPTY_METADATA_TTL_MS
+            val isCacheValid = cacheAgeMs < cacheTtlMs
+
+            if (cachedMetadata != null && isCacheValid) {
                 _uiState.update {
                     it.copy(
                         tmdbReviews = cachedMetadata.tmdbReviews,
@@ -1166,12 +1231,7 @@ constructor(
                     )
                 }
 
-                if (
-                    (fetchedReviews.isNotEmpty() ||
-                        fetchedRatings.isNotEmpty() ||
-                        fetchedRatingBadges.hasAny ||
-                        fetchedOmdbAwards != null) && session != null
-                ) {
+                if (session != null) {
                     databaseRepository.insertItemMetadata(
                         ItemMetadataCacheEntity(
                             itemId = item.id,
@@ -1655,6 +1715,8 @@ data class ItemDetailUiState(
     val mdbRatings: List<MdbListRating> = emptyList(),
     val mdbRatingBadges: MdbListRatingBadges = MdbListRatingBadges(),
     val omdbAwards: String? = null,
+    val wikidataAwards: WikidataAwards? = null,
+    val isLoadingWikidataAwards: Boolean = false,
     val isRatingsFromCache: Boolean = false,
     val movieParts: List<AfinityItem> = emptyList(),
 ) {

--- a/app/src/main/java/com/makd/afinity/ui/item/components/MovieDetailContent.kt
+++ b/app/src/main/java/com/makd/afinity/ui/item/components/MovieDetailContent.kt
@@ -44,6 +44,7 @@ import com.makd.afinity.data.models.media.AfinityItem
 import com.makd.afinity.data.models.media.AfinityMovie
 import com.makd.afinity.data.models.media.getChapterImageUrl
 import com.makd.afinity.data.models.tmdb.TmdbReview
+import com.makd.afinity.data.models.wikidata.WikidataAwards
 import com.makd.afinity.navigation.Destination
 import com.makd.afinity.ui.components.AsyncImage
 import com.makd.afinity.ui.item.components.shared.BaseMediaDetailContent
@@ -63,6 +64,7 @@ fun MovieDetailContent(
     mdbRatings: List<MdbListRating> = emptyList(),
     mdbRatingBadges: MdbListRatingBadges = MdbListRatingBadges(),
     omdbAwards: String? = null,
+    wikidataAwards: WikidataAwards? = null,
     isRatingsFromCache: Boolean = false,
     parts: List<AfinityItem> = emptyList(),
     onSpecialFeatureClick: (AfinityItem) -> Unit,
@@ -81,6 +83,7 @@ fun MovieDetailContent(
         mdbRatings = mdbRatings,
         mdbRatingBadges = mdbRatingBadges,
         omdbAwards = omdbAwards,
+        wikidataAwards = wikidataAwards,
         isRatingsFromCache = isRatingsFromCache,
         onSpecialFeatureClick = onSpecialFeatureClick,
         onBoxSetClick = { boxSet ->

--- a/app/src/main/java/com/makd/afinity/ui/item/components/SeasonDetailContent.kt
+++ b/app/src/main/java/com/makd/afinity/ui/item/components/SeasonDetailContent.kt
@@ -38,6 +38,7 @@ import com.makd.afinity.data.models.media.AfinityEpisode
 import com.makd.afinity.data.models.media.AfinityItem
 import com.makd.afinity.data.models.media.AfinitySeason
 import com.makd.afinity.data.models.tmdb.TmdbReview
+import com.makd.afinity.data.models.wikidata.WikidataAwards
 import com.makd.afinity.data.repository.PreferencesRepository
 import com.makd.afinity.navigation.Destination
 import com.makd.afinity.ui.components.ContinueWatchingCard
@@ -56,6 +57,7 @@ fun SeasonDetailContent(
     tmdbReviews: List<TmdbReview> = emptyList(),
     mdbRatings: List<MdbListRating> = emptyList(),
     mdbRatingBadges: MdbListRatingBadges = MdbListRatingBadges(),
+    wikidataAwards: WikidataAwards? = null,
     isRatingsFromCache: Boolean = false,
     onEpisodeClick: (AfinityEpisode) -> Unit,
     onSpecialFeatureClick: (AfinityItem) -> Unit,
@@ -75,6 +77,7 @@ fun SeasonDetailContent(
         tmdbReviews = tmdbReviews,
         mdbRatings = mdbRatings,
         mdbRatingBadges = mdbRatingBadges,
+        wikidataAwards = wikidataAwards,
         isRatingsFromCache = isRatingsFromCache,
         onSpecialFeatureClick = onSpecialFeatureClick,
         onBoxSetClick = { boxSet ->

--- a/app/src/main/java/com/makd/afinity/ui/item/components/SeriesDetailContent.kt
+++ b/app/src/main/java/com/makd/afinity/ui/item/components/SeriesDetailContent.kt
@@ -41,6 +41,7 @@ import com.makd.afinity.data.models.media.AfinityItem
 import com.makd.afinity.data.models.media.AfinitySeason
 import com.makd.afinity.data.models.media.AfinityShow
 import com.makd.afinity.data.models.tmdb.TmdbReview
+import com.makd.afinity.data.models.wikidata.WikidataAwards
 import com.makd.afinity.navigation.Destination
 import com.makd.afinity.ui.components.AsyncImage
 import com.makd.afinity.ui.components.MediaCountBadge
@@ -61,6 +62,7 @@ fun SeriesDetailContent(
     mdbRatings: List<MdbListRating> = emptyList(),
     mdbRatingBadges: MdbListRatingBadges = MdbListRatingBadges(),
     omdbAwards: String? = null,
+    wikidataAwards: WikidataAwards? = null,
     isRatingsFromCache: Boolean = false,
     onEpisodeClick: (AfinityEpisode) -> Unit,
     onEpisodeMoreClick: (AfinityEpisode) -> Unit,
@@ -76,6 +78,7 @@ fun SeriesDetailContent(
         mdbRatings = mdbRatings,
         mdbRatingBadges = mdbRatingBadges,
         omdbAwards = omdbAwards,
+        wikidataAwards = wikidataAwards,
         isRatingsFromCache = isRatingsFromCache,
         onSpecialFeatureClick = onSpecialFeatureClick,
         onBoxSetClick = { boxSet ->

--- a/app/src/main/java/com/makd/afinity/ui/item/components/shared/BaseMediaDetailContent.kt
+++ b/app/src/main/java/com/makd/afinity/ui/item/components/shared/BaseMediaDetailContent.kt
@@ -41,6 +41,8 @@ import com.makd.afinity.data.models.media.AfinityItem
 import com.makd.afinity.data.models.media.AfinityMovie
 import com.makd.afinity.data.models.media.AfinityShow
 import com.makd.afinity.data.models.tmdb.TmdbReview
+import com.makd.afinity.data.models.wikidata.WikidataAwards
+import com.makd.afinity.navigation.LocalShowAwards
 import com.makd.afinity.navigation.LocalShowRatings
 import com.makd.afinity.ui.components.ratings.communityRatingOf
 import com.makd.afinity.ui.components.ratings.criticRatingOf
@@ -58,6 +60,7 @@ fun BaseMediaDetailContent(
     mdbRatings: List<MdbListRating> = emptyList(),
     mdbRatingBadges: MdbListRatingBadges = MdbListRatingBadges(),
     omdbAwards: String? = null,
+    wikidataAwards: WikidataAwards? = null,
     isRatingsFromCache: Boolean = false,
     onSpecialFeatureClick: (AfinityItem) -> Unit,
     onBoxSetClick: (AfinityBoxSet) -> Unit,
@@ -80,8 +83,25 @@ fun BaseMediaDetailContent(
 
         CastSection(item = item, onPersonClick = onPersonClick, widthSizeClass = widthSizeClass)
 
-        if (!omdbAwards.isNullOrBlank()) {
-            AwardSection(awards = omdbAwards, isFromCache = isRatingsFromCache)
+        if (LocalShowAwards.current) {
+            val omdbHeadline = omdbAwardsHeadline(omdbAwards)
+            val headline =
+                if (omdbHeadline == null && wikidataAwards != null) {
+                    derivedAwardsHeadline(wikidataAwards)
+                } else {
+                    omdbHeadline
+                }
+
+            if (headline != null) {
+                AwardBanner(headline = headline, isFromCache = isRatingsFromCache)
+            }
+
+            if (wikidataAwards != null) {
+                WikidataAwardsSection(
+                    awards = wikidataAwards,
+                    style = AwardsSectionStyle.COLLAPSED_BAR,
+                )
+            }
         }
 
         if (LocalShowRatings.current) {
@@ -89,7 +109,6 @@ fun BaseMediaDetailContent(
                 item = item,
                 mdbRatings = mdbRatings,
                 mdbRatingBadges = mdbRatingBadges,
-                omdbAwards = omdbAwards,
                 tmdbReviews = tmdbReviews,
                 isRatingsFromCache = isRatingsFromCache,
             )
@@ -114,7 +133,6 @@ private fun RatingsAndReviews(
     item: AfinityItem,
     mdbRatings: List<MdbListRating>,
     mdbRatingBadges: MdbListRatingBadges,
-    omdbAwards: String?,
     tmdbReviews: List<TmdbReview>,
     isRatingsFromCache: Boolean,
 ) {
@@ -138,9 +156,8 @@ private fun RatingsAndReviews(
 
     val hasRatings = mdbRatingBadges.hasAny || orderedRatings.isNotEmpty()
     val hasReviews = tmdbReviews.isNotEmpty()
-    val hasAwards = !omdbAwards.isNullOrBlank()
 
-    if (!hasRatings && !hasReviews && !hasAwards) return
+    if (!hasRatings && !hasReviews) return
 
     Column(
         modifier = Modifier.fillMaxWidth(),
@@ -202,9 +219,9 @@ private fun RatingsAndReviews(
 }
 
 @Composable
-private fun AwardSection(awards: String, isFromCache: Boolean) {
-    val mainHighlight = awards.split(".", limit = 2).firstOrNull()?.trim() ?: awards
-    val goldAccent = Color(0xFFD4AF37)
+private fun AwardBanner(headline: String, isFromCache: Boolean) {
+    val mainHighlight = headline
+    val goldAccent = AwardGold
 
     AnimatedVisibility(
         visible = true,

--- a/app/src/main/java/com/makd/afinity/ui/item/components/shared/WikidataAwardsSection.kt
+++ b/app/src/main/java/com/makd/afinity/ui/item/components/shared/WikidataAwardsSection.kt
@@ -1,0 +1,387 @@
+package com.makd.afinity.ui.item.components.shared
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.makd.afinity.R
+import com.makd.afinity.data.models.wikidata.AwardResult
+import com.makd.afinity.data.models.wikidata.WikidataAward
+import com.makd.afinity.data.models.wikidata.WikidataAwards
+
+val AwardGold = Color(0xFFD4AF37)
+
+private const val OPEN_LIST_PREVIEW_GROUPS = 2
+
+private val DOT_SIZE_DP = 8.dp
+
+enum class AwardsSectionStyle {
+    COLLAPSED_BAR,
+    OPEN_LIST,
+}
+
+@Composable
+fun WikidataAwardsSection(
+    awards: WikidataAwards,
+    style: AwardsSectionStyle,
+    modifier: Modifier = Modifier,
+) {
+    if (!awards.found) return
+
+    var showSheet by remember { mutableStateOf(false) }
+
+    when (style) {
+        AwardsSectionStyle.COLLAPSED_BAR ->
+            AwardsSummaryBar(
+                awards = awards,
+                onClick = { showSheet = true },
+                modifier = modifier,
+            )
+        AwardsSectionStyle.OPEN_LIST ->
+            AwardsOpenList(
+                awards = awards,
+                onShowAll = { showSheet = true },
+                modifier = modifier,
+            )
+    }
+
+    if (showSheet) {
+        AwardsSheet(awards = awards, onDismiss = { showSheet = false })
+    }
+}
+
+@Composable
+private fun AwardsSummaryBar(
+    awards: WikidataAwards,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.1f)),
+        modifier = modifier.fillMaxWidth().clickable(onClick = onClick),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Icon(
+                painter = painterResource(id = R.drawable.ic_laurel),
+                contentDescription = null,
+                tint = AwardGold,
+                modifier = Modifier.size(22.dp),
+            )
+            Text(
+                text = awardsSummary(awards),
+                style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
+                color = MaterialTheme.colorScheme.onBackground,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+            Icon(
+                painter = painterResource(id = R.drawable.ic_chevron_right),
+                contentDescription = stringResource(R.string.cd_awards_open),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(20.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun AwardsOpenList(
+    awards: WikidataAwards,
+    onShowAll: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val preview =
+        remember(awards.awards) {
+            awards.awards
+                .groupBy { it.year }
+                .values
+                .take(OPEN_LIST_PREVIEW_GROUPS)
+                .flatten()
+        }
+
+    Column(modifier = modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Text(
+            text = stringResource(R.string.section_awards),
+            style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
+            color = MaterialTheme.colorScheme.onBackground,
+        )
+
+        AwardTimeline(awards = preview)
+
+        if (awards.awards.size > preview.size) {
+            Text(
+                text =
+                    pluralStringResource(
+                        R.plurals.awards_show_all_fmt,
+                        awards.awards.size,
+                        awards.awards.size,
+                    ),
+                style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.SemiBold),
+                color = AwardGold,
+                modifier = Modifier.clickable(onClick = onShowAll),
+            )
+        }
+    }
+}
+
+@Composable
+private fun AwardsSheet(awards: WikidataAwards, onDismiss: () -> Unit) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surfaceContainer,
+        shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
+    ) {
+        Column(
+            modifier =
+                Modifier.fillMaxWidth()
+                    .padding(horizontal = 24.dp, vertical = 16.dp)
+                    .verticalScroll(rememberScrollState())
+        ) {
+            Text(
+                text = stringResource(R.string.section_awards),
+                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = awardsSummary(awards),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 2.dp, bottom = 12.dp),
+            )
+
+            AwardTimeline(awards = awards.awards)
+        }
+    }
+}
+
+@Composable
+private fun AwardTimeline(awards: List<WikidataAward>, modifier: Modifier = Modifier) {
+    val groups = remember(awards) { awards.groupBy { it.year }.toList() }
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        groups.forEachIndexed { index, (year, entries) ->
+            AwardYearGroup(year = year, entries = entries, isLast = index == groups.lastIndex)
+        }
+    }
+}
+
+@Composable
+private fun AwardYearGroup(year: Int?, entries: List<WikidataAward>, isLast: Boolean) {
+    val hasWin = entries.any { it.result == AwardResult.WON }
+    val markerColor = if (hasWin) AwardGold else MaterialTheme.colorScheme.onSurfaceVariant
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier = Modifier.width(20.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Box(modifier = Modifier.size(DOT_SIZE_DP).clip(CircleShape).background(markerColor))
+            }
+
+            Text(
+                text = year?.toString() ?: "—",
+                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                color = markerColor,
+                modifier = Modifier.padding(start = 12.dp),
+            )
+        }
+
+        Row(modifier = Modifier.fillMaxWidth().height(IntrinsicSize.Min)) {
+            Box(
+                modifier = Modifier.width(20.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                if (!isLast) {
+                    VerticalDivider(
+                        modifier = Modifier.fillMaxHeight(),
+                        thickness = 1.dp,
+                        color = MaterialTheme.colorScheme.outline.copy(alpha = 0.2f),
+                    )
+                }
+            }
+
+            Column(
+                modifier =
+                    Modifier.weight(1f)
+                        .padding(
+                            start = 12.dp,
+                            top = 12.dp,
+                            bottom = if (isLast) 8.dp else 28.dp,
+                        ),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                entries.forEach { AwardEntryRow(award = it) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AwardEntryRow(award: WikidataAward) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.Top,
+        ) {
+            Text(
+                text = award.name,
+                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+                color = MaterialTheme.colorScheme.onBackground,
+                modifier = Modifier.weight(1f).padding(end = 8.dp),
+            )
+            AwardResultPill(result = award.result)
+        }
+
+        val detail = (award.works + award.recipients).joinToString(", ")
+        if (detail.isNotBlank()) {
+            Text(
+                text = detail,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+@Composable
+private fun AwardResultPill(result: AwardResult) {
+    val won = result == AwardResult.WON
+    Surface(
+        shape = RoundedCornerShape(4.dp),
+        color =
+            if (won) AwardGold.copy(alpha = 0.18f)
+            else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.15f),
+    ) {
+        Text(
+            text =
+                stringResource(
+                    if (won) R.string.awards_result_won else R.string.awards_result_nominated
+                ),
+            style =
+                MaterialTheme.typography.labelSmall.copy(
+                    fontSize = 9.sp,
+                    fontWeight = FontWeight.ExtraBold,
+                    letterSpacing = 1.sp,
+                ),
+            color = if (won) AwardGold else MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 6.dp, vertical = 3.dp),
+        )
+    }
+}
+
+private val HEADLINE_BODIES =
+    listOf(
+        "Academy Award" to R.plurals.awards_body_oscar_fmt,
+        "Primetime Emmy Award" to R.plurals.awards_body_emmy_fmt,
+        "Daytime Emmy Award" to R.plurals.awards_body_emmy_fmt,
+        "Golden Globe Award" to R.plurals.awards_body_golden_globe_fmt,
+        "BAFTA Award" to R.plurals.awards_body_bafta_fmt,
+        "Screen Actors Guild Award" to R.plurals.awards_body_sag_fmt,
+        "Critics' Choice" to R.plurals.awards_body_critics_choice_fmt,
+    )
+
+fun omdbAwardsHeadline(awards: String?): String? =
+    awards
+        ?.takeIf { it.isNotBlank() }
+        ?.split(".", limit = 2)
+        ?.first()
+        ?.trim()
+        ?.takeIf {
+            it.isNotBlank()
+        }
+
+@Composable
+fun derivedAwardsHeadline(awards: WikidataAwards): String? {
+    val match =
+        HEADLINE_BODIES.firstNotNullOfOrNull { (prefix, plural) ->
+            val wins =
+                awards.awards.count { it.result == AwardResult.WON && it.name.startsWith(prefix) }
+            if (wins > 0) return@firstNotNullOfOrNull Triple(plural, wins, true)
+
+            val nominations =
+                awards.awards.count {
+                    it.result == AwardResult.NOMINATED && it.name.startsWith(prefix)
+                }
+            if (nominations > 0) Triple(plural, nominations, false) else null
+        } ?: return null
+
+    val (plural, count, won) = match
+    val bodyText = pluralStringResource(plural, count, count)
+    return stringResource(
+        if (won) R.string.awards_headline_won_fmt else R.string.awards_headline_nominated_fmt,
+        bodyText,
+    )
+}
+
+@Composable
+private fun awardsSummary(awards: WikidataAwards): String {
+    val wins = awards.wins
+    val nominations = awards.nominations
+    val winsText = pluralStringResource(R.plurals.awards_wins_fmt, wins, wins)
+    val nominationsText =
+        pluralStringResource(R.plurals.awards_nominations_fmt, nominations, nominations)
+
+    return when {
+        wins > 0 && nominations > 0 ->
+            stringResource(R.string.awards_summary_fmt, winsText, nominationsText)
+        wins > 0 -> winsText
+        else -> nominationsText
+    }
+}

--- a/app/src/main/java/com/makd/afinity/ui/onboarding/ServicesHubScreen.kt
+++ b/app/src/main/java/com/makd/afinity/ui/onboarding/ServicesHubScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -65,6 +66,7 @@ import com.makd.afinity.data.models.server.ConnectionType
 import com.makd.afinity.ui.components.AfinityTextField
 import com.makd.afinity.ui.components.connectionIndicatorColor
 import com.makd.afinity.ui.components.connectionLabel
+import com.makd.afinity.ui.item.components.shared.AwardGold
 import com.makd.afinity.ui.settings.SettingsViewModel
 import com.makd.afinity.ui.settings.servers.AudiobookshelfColor
 import com.makd.afinity.ui.settings.servers.CancelColor
@@ -191,10 +193,21 @@ fun ServicesHubScreen(
     val seerrSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val absSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
+    var showWikidataSheet by remember { mutableStateOf(false) }
+    var showWikidataDisconnect by remember { mutableStateOf(false) }
+    val wikidataSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val wikidataEnabled by settingsViewModel.wikidataEnabled.collectAsStateWithLifecycle()
+    val onWikidataTile = {
+        if (wikidataEnabled) showWikidataDisconnect = true else showWikidataSheet = true
+    }
+
     val onSeerrTile = { if (seerrConnected) selected = EditorKind.SEERR else showSeerrSheet = true }
     val onAbsTile = { if (absConnected) selected = EditorKind.ABS else showAbsSheet = true }
     val onRemoteTile = { selected = EditorKind.JELLYFIN }
-    val onRatingsTile = { selected = EditorKind.RATINGS }
+    val onRatingsTile = {
+        settingsViewModel.refreshMdbListUsage()
+        selected = EditorKind.RATINGS
+    }
 
     BoxWithConstraints(
         modifier = modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)
@@ -256,6 +269,8 @@ fun ServicesHubScreen(
                             onAbs = onAbsTile,
                             onRemote = onRemoteTile,
                             onRatings = onRatingsTile,
+                            wikidataEnabled = wikidataEnabled,
+                            onWikidata = onWikidataTile,
                             onFinish = onFinish,
                             onServerManagement = onNavigateToServerManagement,
                             markDone = viewModel::markFirstRunDone,
@@ -317,6 +332,8 @@ fun ServicesHubScreen(
                         onAbs = onAbsTile,
                         onRemote = onRemoteTile,
                         onRatings = onRatingsTile,
+                        wikidataEnabled = wikidataEnabled,
+                        onWikidata = onWikidataTile,
                         onFinish = onFinish,
                         onServerManagement = onNavigateToServerManagement,
                         markDone = viewModel::markFirstRunDone,
@@ -366,6 +383,38 @@ fun ServicesHubScreen(
             }
         }
 
+        if (showWikidataDisconnect) {
+            AlertDialog(
+                onDismissRequest = { showWikidataDisconnect = false },
+                title = { Text(stringResource(R.string.wikidata_disconnect_title)) },
+                text = { Text(stringResource(R.string.wikidata_disconnect_message)) },
+                confirmButton = {
+                    TextButton(
+                        onClick = {
+                            settingsViewModel.setWikidataEnabled(false)
+                            showWikidataDisconnect = false
+                        }
+                    ) {
+                        Text(stringResource(R.string.wikidata_disconnect_action))
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showWikidataDisconnect = false }) {
+                        Text(stringResource(R.string.action_cancel))
+                    }
+                },
+            )
+        }
+        if (showWikidataSheet) {
+            WikidataConnectSheet(
+                sheetState = wikidataSheetState,
+                onDismiss = { showWikidataSheet = false },
+                onEnable = {
+                    settingsViewModel.setWikidataEnabled(true)
+                    showWikidataSheet = false
+                },
+            )
+        }
         if (showSeerrSheet) {
             com.makd.afinity.ui.settings.JellyseerrBottomSheet(
                 onDismiss = { showSeerrSheet = false },
@@ -438,6 +487,8 @@ private fun HubList(
     onAbs: () -> Unit,
     onRemote: () -> Unit,
     onRatings: () -> Unit,
+    wikidataEnabled: Boolean,
+    onWikidata: () -> Unit,
     onFinish: () -> Unit,
     onServerManagement: () -> Unit,
     markDone: () -> Unit,
@@ -542,6 +593,25 @@ private fun HubList(
                 } else {
                     Spacer(Modifier.weight(1f))
                 }
+            }
+
+            Spacer(Modifier.height(12.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                ServiceTile(
+                    iconRes = R.drawable.ic_laurel,
+                    name = stringResource(R.string.services_hub_tile_wikidata),
+                    connected = wikidataEnabled,
+                    accent = AwardGold,
+                    statusText =
+                        stringResource(
+                            if (wikidataEnabled) R.string.services_hub_status_connected
+                            else R.string.services_hub_status_not_set_up
+                        ),
+                    isSelected = false,
+                    onClick = onWikidata,
+                    modifier = Modifier.weight(1f),
+                )
+                Spacer(Modifier.weight(1f))
             }
 
             Spacer(Modifier.height(24.dp))
@@ -874,6 +944,8 @@ private fun RatingsKeys(viewModel: SettingsViewModel) {
         onEditingChange = { editingLabel = if (it) "TMDB" else null },
         onSave = { viewModel.validateAndSaveTmdbKey(it) { editingLabel = null } },
     )
+    val mdbUsage by viewModel.mdbListUsage.collectAsStateWithLifecycle()
+
     RatingKeyRow(
         label = "MDBList",
         labelColor = mdblistColor,
@@ -882,7 +954,15 @@ private fun RatingsKeys(viewModel: SettingsViewModel) {
         error = uiState.mdbListKeyValidationError,
         editing = editingLabel == "MDBList",
         onEditingChange = { editingLabel = if (it) "MDBList" else null },
-        onSave = { viewModel.validateAndSaveMdbListKey(it) { editingLabel = null } },
+        onSave = {
+            viewModel.validateAndSaveMdbListKey(it) {
+                editingLabel = null
+                viewModel.refreshMdbListUsage()
+            }
+        },
+        meta =
+            mdbUsage?.let { stringResource(R.string.mdblist_usage_fmt, it.remaining, it.limit) }
+                ?: stringResource(R.string.mdblist_usage_unknown),
     )
     RatingKeyRow(
         label = "OMDb",
@@ -906,6 +986,7 @@ private fun RatingKeyRow(
     editing: Boolean,
     onEditingChange: (Boolean) -> Unit,
     onSave: (String) -> Unit,
+    meta: String? = null,
 ) {
     var input by remember(currentKey) { mutableStateOf(currentKey) }
 
@@ -931,6 +1012,15 @@ private fun RatingKeyRow(
                         text = maskKey(currentKey),
                         style = MaterialTheme.typography.bodyLarge,
                         maxLines = 1,
+                    )
+                }
+                if (meta != null) {
+                    Text(
+                        text = meta,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        modifier = Modifier.padding(end = 4.dp),
                     )
                 }
                 IconButton(
@@ -974,6 +1064,19 @@ private fun RatingKeyRow(
                         modifier = Modifier.padding(end = 12.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
+                        if (input.isNotBlank()) {
+                            IconButton(
+                                onClick = { input = "" },
+                                modifier = Modifier.size(36.dp),
+                            ) {
+                                Icon(
+                                    painter = painterResource(id = R.drawable.ic_clear),
+                                    contentDescription = stringResource(R.string.action_remove),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.size(20.dp),
+                                )
+                            }
+                        }
                         IconButton(
                             onClick = { onEditingChange(false) },
                             modifier = Modifier.size(36.dp),
@@ -1115,4 +1218,93 @@ private fun DisconnectDialog(serviceName: String, onConfirm: () -> Unit, onDismi
             TextButton(onClick = onDismiss) { Text(stringResource(R.string.action_cancel)) }
         },
     )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun WikidataConnectSheet(
+    sheetState: SheetState,
+    onDismiss: () -> Unit,
+    onEnable: () -> Unit,
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surfaceContainer,
+        shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_laurel),
+                    contentDescription = null,
+                    tint = AwardGold,
+                    modifier = Modifier.size(28.dp),
+                )
+                Text(
+                    text = stringResource(R.string.wikidata_connect_title),
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+
+            Text(
+                text = stringResource(R.string.wikidata_connect_blurb),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            WikidataDisclosureBlock(
+                title = stringResource(R.string.wikidata_connect_sends_title),
+                body = stringResource(R.string.wikidata_connect_sends_body),
+            )
+            WikidataDisclosureBlock(
+                title = stringResource(R.string.wikidata_connect_never_title),
+                body = stringResource(R.string.wikidata_connect_never_body),
+            )
+
+            Text(
+                text = stringResource(R.string.wikidata_scope_note),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Button(onClick = onEnable, modifier = Modifier.fillMaxWidth()) {
+                Text(stringResource(R.string.wikidata_connect_action))
+            }
+            Spacer(Modifier.height(8.dp))
+        }
+    }
+}
+
+@Composable
+private fun WikidataDisclosureBlock(title: String, body: String) {
+    Surface(
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(
+            modifier = Modifier.padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = body,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
+    }
 }

--- a/app/src/main/java/com/makd/afinity/ui/person/PersonScreen.kt
+++ b/app/src/main/java/com/makd/afinity/ui/person/PersonScreen.kt
@@ -64,6 +64,7 @@ fun PersonScreen(
                     person = uiState.person!!,
                     movies = uiState.movies,
                     shows = uiState.shows,
+                    awards = uiState.awards,
                     onItemClick = { item ->
                         val route =
                             Destination.createItemDetailRoute(

--- a/app/src/main/java/com/makd/afinity/ui/person/PersonViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/person/PersonViewModel.kt
@@ -13,9 +13,13 @@ import com.makd.afinity.data.models.media.AfinityMovie
 import com.makd.afinity.data.models.media.AfinityPersonDetail
 import com.makd.afinity.data.models.media.AfinityShow
 import com.makd.afinity.data.models.media.withUserDataFrom
+import com.makd.afinity.data.models.wikidata.WikidataAwards
+import com.makd.afinity.data.models.wikidata.WikidataSubjectType
 import com.makd.afinity.data.repository.AppDataRepository
+import com.makd.afinity.data.repository.PreferencesRepository
 import com.makd.afinity.data.repository.media.MediaRepository
 import com.makd.afinity.data.repository.userdata.UserDataRepository
+import com.makd.afinity.data.repository.wikidata.WikidataAwardsRepository
 import com.makd.afinity.data.store.ItemStore
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -41,6 +45,8 @@ constructor(
     private val adminChangeBroadcaster: AdminChangeBroadcaster,
     private val mediaChangeManager: MediaChangeManager,
     private val itemStore: ItemStore,
+    private val wikidataAwardsRepository: WikidataAwardsRepository,
+    private val preferencesRepository: PreferencesRepository,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
@@ -57,6 +63,8 @@ constructor(
     val uiState: StateFlow<PersonUiState> = _uiState.asStateFlow()
 
     private var lastLoadedAt = 0L
+
+    private var awardsTmdbId: String? = null
 
     init {
         viewModelScope.launch { adminChangeBroadcaster.itemChanged.collect { loadPersonDetails() } }
@@ -188,6 +196,7 @@ constructor(
 
                     _uiState.update { it.copy(person = person, isLoading = false) }
                     lastLoadedAt = System.currentTimeMillis()
+                    loadAwardsFor(person)
 
                     if (person.hasIncompleteMetadata()) {
                         val rechecked = mediaRepository.getPersonWithoutRefresh(personId)
@@ -212,6 +221,33 @@ constructor(
                             },
                     )
                 }
+            }
+        }
+    }
+
+    private fun loadAwardsFor(person: AfinityPersonDetail) {
+        val tmdbId = person.providerIds?.get("Tmdb")
+        if (tmdbId.isNullOrBlank()) {
+            awardsTmdbId = null
+            _uiState.update { it.copy(awards = null, isLoadingAwards = false) }
+            return
+        }
+        if (tmdbId == awardsTmdbId && _uiState.value.awards != null) return
+        awardsTmdbId = tmdbId
+
+        viewModelScope.launch {
+            if (
+                !preferencesRepository.getShowAwards() ||
+                    !preferencesRepository.getWikidataEnabled()
+            ) {
+                _uiState.update { it.copy(awards = null, isLoadingAwards = false) }
+                return@launch
+            }
+            _uiState.update { it.copy(isLoadingAwards = true) }
+            val awards = wikidataAwardsRepository.getAwards(WikidataSubjectType.PERSON, tmdbId)
+            if (awardsTmdbId != tmdbId) return@launch
+            _uiState.update {
+                it.copy(awards = awards.takeIf { loaded -> loaded.found }, isLoadingAwards = false)
             }
         }
     }
@@ -271,4 +307,6 @@ data class PersonUiState(
     val shows: List<AfinityShow> = emptyList(),
     val isLoading: Boolean = false,
     val error: String? = null,
+    val awards: WikidataAwards? = null,
+    val isLoadingAwards: Boolean = false,
 )

--- a/app/src/main/java/com/makd/afinity/ui/person/components/PersonDetailContent.kt
+++ b/app/src/main/java/com/makd/afinity/ui/person/components/PersonDetailContent.kt
@@ -73,10 +73,14 @@ import com.makd.afinity.data.models.media.AfinityItem
 import com.makd.afinity.data.models.media.AfinityMovie
 import com.makd.afinity.data.models.media.AfinityPersonDetail
 import com.makd.afinity.data.models.media.AfinityShow
+import com.makd.afinity.data.models.wikidata.WikidataAwards
 import com.makd.afinity.navigation.LocalPlayerOffset
+import com.makd.afinity.navigation.LocalShowAwards
 import com.makd.afinity.ui.components.AsyncImage
 import com.makd.afinity.ui.components.FavoriteToggleButton
 import com.makd.afinity.ui.components.MediaItemCard
+import com.makd.afinity.ui.item.components.shared.AwardsSectionStyle
+import com.makd.afinity.ui.item.components.shared.WikidataAwardsSection
 import com.makd.afinity.ui.theme.CardDimensions.portraitWidth
 import com.makd.afinity.ui.utils.htmlToAnnotatedString
 import com.makd.afinity.ui.utils.verticalLayoutOffset
@@ -88,6 +92,7 @@ fun PersonDetailContent(
     shows: List<AfinityShow>,
     onItemClick: (AfinityItem) -> Unit,
     onToggleFavorite: () -> Unit,
+    awards: WikidataAwards?,
     widthSizeClass: WindowWidthSizeClass,
     modifier: Modifier = Modifier,
     lazyListState: LazyListState = rememberLazyListState(),
@@ -102,6 +107,7 @@ fun PersonDetailContent(
             shows = shows,
             onItemClick = onItemClick,
             onToggleFavorite = onToggleFavorite,
+            awards = awards,
             modifier = modifier,
             lazyListState = lazyListState,
         )
@@ -112,6 +118,7 @@ fun PersonDetailContent(
             shows = shows,
             onItemClick = onItemClick,
             onToggleFavorite = onToggleFavorite,
+            awards = awards,
             widthSizeClass = widthSizeClass,
             modifier = modifier,
             lazyListState = lazyListState,
@@ -126,6 +133,7 @@ private fun LandscapePersonDetailContent(
     shows: List<AfinityShow>,
     onItemClick: (AfinityItem) -> Unit,
     onToggleFavorite: () -> Unit,
+    awards: WikidataAwards?,
     modifier: Modifier = Modifier,
     lazyListState: LazyListState = rememberLazyListState(),
 ) {
@@ -204,6 +212,7 @@ private fun LandscapePersonDetailContent(
                             shows = shows,
                             onItemClick = onItemClick,
                             cardWidth = 140.dp,
+                            awards = awards,
                         )
                     }
                 }
@@ -220,6 +229,7 @@ private fun PortraitPersonDetailContent(
     shows: List<AfinityShow>,
     onItemClick: (AfinityItem) -> Unit,
     onToggleFavorite: () -> Unit,
+    awards: WikidataAwards?,
     widthSizeClass: WindowWidthSizeClass,
     modifier: Modifier = Modifier,
     lazyListState: LazyListState = rememberLazyListState(),
@@ -262,6 +272,7 @@ private fun PortraitPersonDetailContent(
                     shows = shows,
                     onItemClick = onItemClick,
                     cardWidth = cardWidth,
+                    awards = awards,
                 )
             }
         }
@@ -275,9 +286,14 @@ private fun PersonSharedContentBlocks(
     shows: List<AfinityShow>,
     onItemClick: (AfinityItem) -> Unit,
     cardWidth: Dp,
+    awards: WikidataAwards?,
 ) {
     if (person.overview.isNotBlank()) {
         PersonOverviewSection(overview = person.overview)
+    }
+
+    if (awards != null && LocalShowAwards.current) {
+        WikidataAwardsSection(awards = awards, style = AwardsSectionStyle.OPEN_LIST)
     }
 
     if (movies.isNotEmpty()) {

--- a/app/src/main/java/com/makd/afinity/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/com/makd/afinity/ui/player/PlayerActivity.kt
@@ -33,6 +33,7 @@ import androidx.media3.common.util.UnstableApi
 import com.makd.afinity.R
 import com.makd.afinity.data.models.player.PlayerEvent
 import com.makd.afinity.data.repository.PreferencesRepository
+import com.makd.afinity.navigation.LocalShowAwards
 import com.makd.afinity.navigation.LocalShowRatings
 import com.makd.afinity.ui.theme.AFinityTheme
 import dagger.hilt.android.AndroidEntryPoint
@@ -141,6 +142,8 @@ class PlayerActivity : AppCompatActivity() {
                 preferencesRepository.getDynamicColorsFlow().collectAsState(initial = true)
             val showRatings by
                 preferencesRepository.getShowRatingsFlow().collectAsState(initial = true)
+            val showAwards by
+                preferencesRepository.getShowAwardsFlow().collectAsState(initial = true)
 
             val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
@@ -163,7 +166,10 @@ class PlayerActivity : AppCompatActivity() {
             }
 
             AFinityTheme(themeMode = themeMode, dynamicColor = dynamicColors) {
-                CompositionLocalProvider(LocalShowRatings provides showRatings) {
+                CompositionLocalProvider(
+                    LocalShowRatings provides showRatings,
+                    LocalShowAwards provides showAwards,
+                ) {
                     PlayerScreenWrapper(
                         itemId = itemId,
                         mediaSourceId = mediaSourceId,

--- a/app/src/main/java/com/makd/afinity/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/player/PlayerViewModel.kt
@@ -88,6 +88,7 @@ import com.makd.afinity.player.common.TrackSelection
 import com.makd.afinity.player.mpv.MPVPlayer
 import com.makd.afinity.ui.player.utils.VolumeManager
 import com.makd.afinity.util.formatFileSize
+import com.makd.afinity.util.redactUrl
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.github.peerless2012.ass.media.AssHandler
@@ -1918,7 +1919,7 @@ constructor(
 
         try {
             Timber.d("Loading live channel: $channelName ($channelId)")
-            Timber.d("Stream URL: $streamUrl")
+            Timber.d("Stream URL: ${redactUrl(streamUrl)}")
             val userAgent = "AFinity/${BuildConfig.VERSION_NAME} (Android; ExoPlayer)"
 
             if (player is MPVPlayer) {

--- a/app/src/main/java/com/makd/afinity/ui/player/PlayerWrapperViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/player/PlayerWrapperViewModel.kt
@@ -13,6 +13,7 @@ import com.makd.afinity.data.models.media.AfinityItem
 import com.makd.afinity.data.repository.DatabaseRepository
 import com.makd.afinity.data.repository.livetv.LiveTvRepository
 import com.makd.afinity.data.repository.media.MediaRepository
+import com.makd.afinity.util.redactUrl
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.async
@@ -109,7 +110,9 @@ constructor(
 
                 val playbackInfo = playbackInfoDeferred.await()
                 if (playbackInfo != null) {
-                    Timber.d("PlayerWrapperViewModel: Got stream URL: ${playbackInfo.streamUrl}")
+                    Timber.d(
+                        "PlayerWrapperViewModel: Got stream URL: ${redactUrl(playbackInfo.streamUrl)}"
+                    )
                     _livePlaybackInfo.value = playbackInfo
                     _liveStreamUrl.value = playbackInfo.streamUrl
                 } else {

--- a/app/src/main/java/com/makd/afinity/ui/player/components/PlayerControls.kt
+++ b/app/src/main/java/com/makd/afinity/ui/player/components/PlayerControls.kt
@@ -91,6 +91,7 @@ import com.makd.afinity.data.models.media.AfinityPerson
 import com.makd.afinity.data.models.media.AfinityShow
 import com.makd.afinity.data.models.player.PlayerEvent
 import com.makd.afinity.data.models.syncplay.SyncPlayMemberInfo
+import com.makd.afinity.navigation.LocalShowAwards
 import com.makd.afinity.navigation.LocalShowRatings
 import com.makd.afinity.player.common.TrackMapping
 import com.makd.afinity.ui.components.AfinityBadge
@@ -101,6 +102,7 @@ import com.makd.afinity.ui.components.ratings.criticRatingOf
 import com.makd.afinity.ui.components.ratings.displayPriority
 import com.makd.afinity.ui.components.ratings.excludingSupersededBy
 import com.makd.afinity.ui.components.ratings.toDisplay
+import com.makd.afinity.ui.item.components.shared.omdbAwardsHeadline
 import com.makd.afinity.ui.livetv.components.LiveBadge
 import com.makd.afinity.ui.player.PlayerViewModel
 import com.makd.afinity.ui.player.toLocalizedLanguageName
@@ -1651,16 +1653,14 @@ private fun PauseDetailsOverlay(
                 emptyList()
             } else {
                 (listOfNotNull(communityRatingOf(communityRating), criticRatingOf(criticRating)) +
-                        uiState.mdbRatings
-                            .excludingSupersededBy(criticRating)
-                            .sortedBy { it.displayPriority() })
+                        uiState.mdbRatings.excludingSupersededBy(criticRating).sortedBy {
+                            it.displayPriority()
+                        })
                     .mapNotNull { it.toDisplay() }
             }
         }
     val awardsHighlight =
-        uiState.omdbAwards
-            ?.takeIf { it.isNotBlank() }
-            ?.let { it.split(".", limit = 2).firstOrNull()?.trim() ?: it }
+        if (LocalShowAwards.current) omdbAwardsHeadline(uiState.omdbAwards) else null
 
     Box(modifier = Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.5f))) {
         Column(

--- a/app/src/main/java/com/makd/afinity/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/makd/afinity/ui/settings/SettingsViewModel.kt
@@ -8,6 +8,7 @@ import com.makd.afinity.data.manager.OfflineModeManager
 import com.makd.afinity.data.manager.SessionManager
 import com.makd.afinity.data.models.HomeRow
 import com.makd.afinity.data.models.common.EpisodeLayout
+import com.makd.afinity.data.models.mdblist.MdbListUsage
 import com.makd.afinity.data.models.player.AssRenderMode
 import com.makd.afinity.data.models.player.MpvAudioOutput
 import com.makd.afinity.data.models.player.MpvGpuApi
@@ -171,6 +172,24 @@ constructor(
                 scope = viewModelScope,
                 started = SharingStarted.WhileSubscribed(5000),
                 initialValue = true,
+            )
+
+    val showAwards: StateFlow<Boolean> =
+        preferencesRepository
+            .getShowAwardsFlow()
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5000),
+                initialValue = true,
+            )
+
+    val wikidataEnabled: StateFlow<Boolean> =
+        preferencesRepository
+            .getWikidataEnabledFlow()
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5000),
+                initialValue = false,
             )
 
     init {
@@ -1081,6 +1100,38 @@ constructor(
 
     fun setAppFont(fontName: String) {
         viewModelScope.launch { preferencesRepository.setAppFont(fontName) }
+    }
+
+    fun toggleShowAwards(enabled: Boolean) {
+        viewModelScope.launch { preferencesRepository.setShowAwards(enabled) }
+    }
+
+    fun setWikidataEnabled(enabled: Boolean) {
+        viewModelScope.launch { preferencesRepository.setWikidataEnabled(enabled) }
+    }
+
+    private val _mdbListUsage = MutableStateFlow<MdbListUsage?>(null)
+    val mdbListUsage: StateFlow<MdbListUsage?> = _mdbListUsage.asStateFlow()
+
+    fun refreshMdbListUsage() {
+        val key = mdbListApiKey.value
+        if (key.isBlank()) {
+            _mdbListUsage.value = null
+            return
+        }
+
+        viewModelScope.launch {
+            _mdbListUsage.value =
+                try {
+                    val user = mdbListApiService.getUser(key)
+                    user.apiRequests?.let {
+                        MdbListUsage(used = user.apiRequestsCount ?: 0, limit = it)
+                    }
+                } catch (e: Exception) {
+                    Timber.w(e, "Failed to load MDBList usage")
+                    null
+                }
+        }
     }
 
     fun toggleShowRatings(enabled: Boolean) {

--- a/app/src/main/java/com/makd/afinity/ui/settings/appearance/AppearanceOptionsScreen.kt
+++ b/app/src/main/java/com/makd/afinity/ui/settings/appearance/AppearanceOptionsScreen.kt
@@ -59,6 +59,7 @@ fun AppearanceOptionsScreen(
     val librariesInDrawer by viewModel.librariesInDrawer.collectAsStateWithLifecycle()
     val episodeLayout by viewModel.episodeLayout.collectAsStateWithLifecycle()
     val showRatings by viewModel.showRatings.collectAsStateWithLifecycle()
+    val showAwards by viewModel.showAwards.collectAsStateWithLifecycle()
     val appFont by viewModel.appFont.collectAsStateWithLifecycle()
     val playerOffset = LocalPlayerOffset.current
 
@@ -195,6 +196,14 @@ fun AppearanceOptionsScreen(
                         subtitle = stringResource(R.string.pref_show_ratings_summary),
                         checked = showRatings,
                         onCheckedChange = viewModel::toggleShowRatings,
+                    )
+                    SettingsDivider()
+                    SettingsSwitchItem(
+                        icon = painterResource(id = R.drawable.ic_laurel),
+                        title = stringResource(R.string.pref_show_awards_title),
+                        subtitle = stringResource(R.string.pref_show_awards_summary),
+                        checked = showAwards,
+                        onCheckedChange = viewModel::toggleShowAwards,
                     )
                 }
             }

--- a/app/src/main/java/com/makd/afinity/util/UrlRedaction.kt
+++ b/app/src/main/java/com/makd/afinity/util/UrlRedaction.kt
@@ -1,0 +1,7 @@
+package com.makd.afinity.util
+
+private val SensitiveQueryParams = Regex("(?i)(api_?key|token|accessToken)=[^&\\s]+")
+
+fun redactSecrets(value: String): String = value.replace(SensitiveQueryParams, "$1=[REDACTED]")
+
+fun redactUrl(url: String?): String = url?.let { redactSecrets(it) } ?: "null"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1239,6 +1239,66 @@
     <string name="section_favorite_playlists">Favorite Playlists</string>
     <string name="section_ratings">Ratings</string>
 
+    <string name="section_awards">Awards</string>
+    <plurals name="awards_wins_fmt">
+        <item quantity="one">%1$d win</item>
+        <item quantity="other">%1$d wins</item>
+    </plurals>
+    <plurals name="awards_nominations_fmt">
+        <item quantity="one">%1$d nomination</item>
+        <item quantity="other">%1$d nominations</item>
+    </plurals>
+    <string name="awards_summary_fmt">%1$s · %2$s</string>
+    <string name="awards_result_won">WON</string>
+    <string name="awards_result_nominated">NOM</string>
+    <plurals name="awards_show_all_fmt">
+        <item quantity="one">Show %1$d award</item>
+        <item quantity="other">Show all %1$d awards</item>
+    </plurals>
+    <string name="cd_awards_open">Open awards</string>
+    <string name="mdblist_usage_fmt">%1$d/%2$d left</string>
+    <string name="mdblist_usage_unknown">—</string>
+    <string name="services_hub_tile_wikidata">Wikidata</string>
+    <string name="wikidata_connect_title">Connect Wikidata</string>
+    <string name="wikidata_connect_blurb">Award wins and nominations for films, shows and people. Free and public — no account or API key needed.</string>
+    <string name="wikidata_connect_sends_title">What AFinity sends</string>
+    <string name="wikidata_connect_sends_body">The TMDB id of an item when you open its detail screen, and your IP address, to Wikimedia\'s public query service.</string>
+    <string name="wikidata_connect_never_title">What it never sends</string>
+    <string name="wikidata_connect_never_body">Nothing from your Jellyfin server — no account, token, server address or watch history.</string>
+    <string name="wikidata_connect_action">Enable</string>
+    <string name="wikidata_scope_note">This applies to every server and profile on this device, not just the one you\'re signed into.</string>
+    <string name="wikidata_disconnect_title">Disconnect Wikidata?</string>
+    <string name="wikidata_disconnect_message">Award history will stop loading on every server and profile on this device. Nothing already saved is deleted.</string>
+    <string name="wikidata_disconnect_action">Disconnect</string>
+    <string name="pref_show_awards_title">Show awards</string>
+    <string name="pref_show_awards_summary">Award banner and win history on detail screens</string>
+    <string name="awards_headline_won_fmt">Won %1$s</string>
+    <string name="awards_headline_nominated_fmt">Nominated for %1$s</string>
+    <plurals name="awards_body_oscar_fmt">
+        <item quantity="one">%1$d Oscar</item>
+        <item quantity="other">%1$d Oscars</item>
+    </plurals>
+    <plurals name="awards_body_emmy_fmt">
+        <item quantity="one">%1$d Emmy</item>
+        <item quantity="other">%1$d Emmys</item>
+    </plurals>
+    <plurals name="awards_body_golden_globe_fmt">
+        <item quantity="one">%1$d Golden Globe</item>
+        <item quantity="other">%1$d Golden Globes</item>
+    </plurals>
+    <plurals name="awards_body_bafta_fmt">
+        <item quantity="one">%1$d BAFTA</item>
+        <item quantity="other">%1$d BAFTAs</item>
+    </plurals>
+    <plurals name="awards_body_sag_fmt">
+        <item quantity="one">%1$d SAG Award</item>
+        <item quantity="other">%1$d SAG Awards</item>
+    </plurals>
+    <plurals name="awards_body_critics_choice_fmt">
+        <item quantity="one">%1$d Critics\' Choice Award</item>
+        <item quantity="other">%1$d Critics\' Choice Awards</item>
+    </plurals>
+
     <string name="warning_http_insecure">Warning: Connecting over HTTP sends your password in plain text. HTTPS is highly recommended.</string>
 
     <string name="dialog_restart_server_title">Restart Server</string>


### PR DESCRIPTION
This commit introduces a comprehensive awards tracking system powered by Wikidata, allowing users to view detailed win and nomination histories for movies, shows, and people. It includes a robust caching layer, SPARQL-based query infrastructure, and a new UI suite for timeline-style award displays.

### Key Changes:

*   **Wikidata Integration**:
    *   **Networking**: Added `WikidataApiService` and `WikidataAwardQueries` to perform SPARQL lookups using TMDB identifiers.
    *   **Parsing**: Implemented `WikidataAwardParser` to transform complex SPARQL responses into a unified `WikidataAwards` model, featuring logic to group results by year and deduplicate "Won" vs. "Nominated" entries.
    *   **Repository**: Created `WikidataAwardsRepository` to manage data flow, handle in-flight request de-duplication, and manage multi-tier TTL (Time-To-Live) for positive and negative caches.

*   **Persistence & Caching**:
    *   **Database**: Introduced `WikidataAwardsCacheEntity` and `WikidataAwardsDao` with a Room migration (v70 to v71).
    *   **Metadata Refactoring**: Updated `ItemDetailViewModel` to use differentiated cache expiration (48h for populated metadata vs. 6h for empty results) to improve refresh reliability.

*   **UI & Presentation**:
    *   **`WikidataAwardsSection`**: Created a new UI component supporting two styles: a `COLLAPSED_BAR` for item headers and an `OPEN_LIST` for detailed timelines.
    *   **Award Timeline**: Implemented a vertical timeline view with distinct markers for wins (gold) and nominations, including a bottom sheet for full history.
    *   **Person Support**: Extended person detail screens to fetch and display awards for actors and directors by resolving their TMDB IDs.
    *   **Preferences**: Added global toggles for "Show Awards" and "Wikidata Enabled," including a dedicated disclosure and opt-in flow in the Services Hub.

*   **Security & Utilities**:
    *   **URL Redaction**: Introduced `UrlRedaction.kt` to automatically strip sensitive parameters (API keys, tokens) from logs across the network layer and media workers.
    *   **MDBList Usage**: Added an API usage tracker in Settings to show remaining MDBList requests.

*   **Refinement**:
    *   Centralized award headline logic to prioritize OMDb headlines while falling back to derived Wikidata summaries when applicable.
    *   Updated `PlayerControls` to respect the new `LocalShowAwards` preference.